### PR TITLE
Add arbitrary guard to unbounded cert rotation check loop

### DIFF
--- a/depot/containerstore/credmanager_test.go
+++ b/depot/containerstore/credmanager_test.go
@@ -308,13 +308,17 @@ var _ = Describe("CredManager", func() {
 							// similar to eventually but faster, to ensure we sample the cert
 							// file as soon as it is overwritten. stop as soon as we see a
 							// change to the file
-							for {
+							//
+							// arbitrary limit to prevent infinite loop
+							limit := 100000
+							for ; limit > 0; limit-- {
 								_, certBytes := readKeyAndCert()
 								after = string(certBytes)
 								if after != before {
 									break
 								}
 							}
+							Expect(limit).To(BeNumerically(">", 0))
 
 							block, _ := pem.Decode([]byte(after))
 							Expect(block).NotTo(BeNil(), "invalid data in cert file")
@@ -328,13 +332,17 @@ var _ = Describe("CredManager", func() {
 							// similar to eventually but faster, to ensure we sample the key
 							// file as soon as it is overwritten. stop as soon as we see a
 							// change to the file
-							for {
+							//
+							// arbitrary limit to prevent infinite loop
+							limit := 100000
+							for ; limit > 0; limit-- {
 								keyBytes, _ := readKeyAndCert()
 								after = string(keyBytes)
 								if after != before {
 									break
 								}
 							}
+							Expect(limit).To(BeNumerically(">", 0))
 
 							block, _ := pem.Decode([]byte(after))
 							Expect(block).NotTo(BeNil(), "invalid data in key file")


### PR DESCRIPTION
On Windows when the credmanager fails the test will hang on this loop, without any chance of exiting.

This issue is also hidden on Windows by a race between the `credmanager.generateCreds()` method and the `readKeyAndCert()` function in the tests. This race causes the tests to sometimes fail before you can see the unbounded loop issue (so run it a couple times on Windows).  When stuck, the arbitrary limit of 10,000 iterations takes about 15 seconds to occur.

**Example failure:**
```
CredManager
C:/Users/Administrator/workspace/diego-windows-release/diego-release/src/code.cloudfoundry.org/executor/depot/containerstore/credmanager_test.go:486
  WithCreds
  C:/Users/Administrator/workspace/diego-windows-release/diego-release/src/code.cloudfoundry.org/executor/depot/containerstore/credmanager_test.go:485
    Runner
    C:/Users/Administrator/workspace/diego-windows-release/diego-release/src/code.cloudfoundry.org/executor/depot/containerstore/credmanager_test.go:484
      when the certificate is about to expire
      C:/Users/Administrator/workspace/diego-windows-release/diego-release/src/code.cloudfoundry.org/executor/depot/containerstore/credmanager_test.go:394
        when the certificate validity is less than 4 hours
        C:/Users/Administrator/workspace/diego-windows-release/diego-release/src/code.cloudfoundry.org/executor/depot/containerstore/credmanager_test.go:368
          when 5 seconds prior to expiry
          C:/Users/Administrator/workspace/diego-windows-release/diego-release/src/code.cloudfoundry.org/executor/depot/containerstore/credmanager_test.go:367
            rotates the key atomically [It]
            C:/Users/Administrator/workspace/diego-windows-release/diego-release/src/code.cloudfoundry.org/executor/depot/containerstore/credmanager_test.go:341

            Expected
                <int>: 0
            to be >
                <int>: 0

            C:/Users/Administrator/workspace/diego-windows-release/diego-release/src/code.cloudfoundry.org/executor/depot/containerstore/credmanager_test.go:335
```

Signed-off-by: Charlie Vieth <cviethjr@pivotal.io>