### PR TITLE
Use diego logging client in place of compatibility

### DIFF
--- a/containermetrics/stats_reporter.go
+++ b/containermetrics/stats_reporter.go
@@ -7,8 +7,8 @@ import (
 	"github.com/cloudfoundry/sonde-go/events"
 
 	"code.cloudfoundry.org/clock"
+	loggingclient "code.cloudfoundry.org/diego-logging-client"
 	"code.cloudfoundry.org/executor"
-	loggregator_v2 "code.cloudfoundry.org/go-loggregator/compatibility"
 	"code.cloudfoundry.org/lager"
 )
 
@@ -20,7 +20,7 @@ type StatsReporter struct {
 	executorClient executor.Client
 
 	cpuInfos     map[string]cpuInfo
-	metronClient loggregator_v2.IngressClient
+	metronClient loggingclient.IngressClient
 }
 
 type cpuInfo struct {
@@ -28,7 +28,7 @@ type cpuInfo struct {
 	timeOfSample   time.Time
 }
 
-func NewStatsReporter(logger lager.Logger, interval time.Duration, clock clock.Clock, executorClient executor.Client, metronClient loggregator_v2.IngressClient) *StatsReporter {
+func NewStatsReporter(logger lager.Logger, interval time.Duration, clock clock.Clock, executorClient executor.Client, metronClient loggingclient.IngressClient) *StatsReporter {
 	return &StatsReporter{
 		logger: logger,
 

--- a/containermetrics/stats_reporter_test.go
+++ b/containermetrics/stats_reporter_test.go
@@ -5,10 +5,10 @@ import (
 	"time"
 
 	"code.cloudfoundry.org/clock/fakeclock"
+	mfakes "code.cloudfoundry.org/diego-logging-client/testhelpers"
 	"code.cloudfoundry.org/executor"
 	"code.cloudfoundry.org/executor/containermetrics"
 	efakes "code.cloudfoundry.org/executor/fakes"
-	mfakes "code.cloudfoundry.org/go-loggregator/testhelpers/fakes/v1"
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/lager/lagertest"
 	msfake "github.com/cloudfoundry/dropsonde/metric_sender/fake"

--- a/depot/containerstore/containerstore.go
+++ b/depot/containerstore/containerstore.go
@@ -6,11 +6,11 @@ import (
 	"time"
 
 	"code.cloudfoundry.org/clock"
+	loggingclient "code.cloudfoundry.org/diego-logging-client"
 	"code.cloudfoundry.org/executor"
 	"code.cloudfoundry.org/executor/depot/event"
 	"code.cloudfoundry.org/executor/depot/transformer"
 	"code.cloudfoundry.org/garden"
-	loggregator_v2 "code.cloudfoundry.org/go-loggregator/compatibility"
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/volman"
 	"github.com/tedsuo/ifrit"
@@ -69,7 +69,7 @@ type containerStore struct {
 	containers        *nodeMap
 	eventEmitter      event.Hub
 	clock             clock.Clock
-	metronClient      loggregator_v2.IngressClient
+	metronClient      loggingclient.IngressClient
 
 	declarativeHealthcheckPath string
 
@@ -87,7 +87,7 @@ func New(
 	eventEmitter event.Hub,
 	transformer transformer.Transformer,
 	trustedSystemCertificatesPath string,
-	metronClient loggregator_v2.IngressClient,
+	metronClient loggingclient.IngressClient,
 	declarativeHealthcheckPath string,
 ) ContainerStore {
 	return &containerStore{

--- a/depot/containerstore/containerstore_test.go
+++ b/depot/containerstore/containerstore_test.go
@@ -18,12 +18,12 @@ import (
 
 	"code.cloudfoundry.org/bbs/models"
 	"code.cloudfoundry.org/clock/fakeclock"
+	mfakes "code.cloudfoundry.org/diego-logging-client/testhelpers"
 	"code.cloudfoundry.org/executor"
 	"code.cloudfoundry.org/executor/depot/containerstore"
 	"code.cloudfoundry.org/executor/depot/containerstore/containerstorefakes"
 	"code.cloudfoundry.org/executor/depot/transformer/faketransformer"
 	"code.cloudfoundry.org/garden"
-	mfakes "code.cloudfoundry.org/go-loggregator/testhelpers/fakes/v1"
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/volman"
 	"code.cloudfoundry.org/volman/volmanfakes"

--- a/depot/containerstore/credmanager.go
+++ b/depot/containerstore/credmanager.go
@@ -18,9 +18,9 @@ import (
 	"github.com/tedsuo/ifrit"
 
 	"code.cloudfoundry.org/clock"
+	loggingclient "code.cloudfoundry.org/diego-logging-client"
 	"code.cloudfoundry.org/executor"
 	"code.cloudfoundry.org/garden"
-	loggregator_v2 "code.cloudfoundry.org/go-loggregator/compatibility"
 	"code.cloudfoundry.org/lager"
 )
 
@@ -56,7 +56,7 @@ func (c *noopManager) Runner(lager.Logger, executor.Container) ifrit.Runner {
 
 type credManager struct {
 	logger             lager.Logger
-	metronClient       loggregator_v2.IngressClient
+	metronClient       loggingclient.IngressClient
 	credDir            string
 	validityPeriod     time.Duration
 	entropyReader      io.Reader
@@ -68,7 +68,7 @@ type credManager struct {
 
 func NewCredManager(
 	logger lager.Logger,
-	metronClient loggregator_v2.IngressClient,
+	metronClient loggingclient.IngressClient,
 	credDir string,
 	validityPeriod time.Duration,
 	entropyReader io.Reader,

--- a/depot/containerstore/credmanager_test.go
+++ b/depot/containerstore/credmanager_test.go
@@ -16,10 +16,10 @@ import (
 	"time"
 
 	"code.cloudfoundry.org/clock/fakeclock"
+	mfakes "code.cloudfoundry.org/diego-logging-client/testhelpers"
 	"code.cloudfoundry.org/executor"
 	"code.cloudfoundry.org/executor/depot/containerstore"
 	"code.cloudfoundry.org/garden"
-	mfakes "code.cloudfoundry.org/go-loggregator/testhelpers/fakes/v1"
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/lager/lagertest"
 	. "github.com/onsi/ginkgo"

--- a/depot/containerstore/helpers.go
+++ b/depot/containerstore/helpers.go
@@ -6,16 +6,16 @@ import (
 	"strings"
 
 	"code.cloudfoundry.org/bbs/models"
+	loggingclient "code.cloudfoundry.org/diego-logging-client"
 	"code.cloudfoundry.org/executor"
 	"code.cloudfoundry.org/executor/depot/log_streamer"
 	"code.cloudfoundry.org/garden"
-	loggregator_v2 "code.cloudfoundry.org/go-loggregator/compatibility"
 	"code.cloudfoundry.org/lager"
 )
 
 var ErrIPRangeConversionFailed = errors.New("failed to convert destination to ip range")
 
-func logStreamerFromLogConfig(conf executor.LogConfig, metronClient loggregator_v2.IngressClient) log_streamer.LogStreamer {
+func logStreamerFromLogConfig(conf executor.LogConfig, metronClient loggingclient.IngressClient) log_streamer.LogStreamer {
 	return log_streamer.New(
 		conf.Guid,
 		conf.SourceName,

--- a/depot/containerstore/storenode.go
+++ b/depot/containerstore/storenode.go
@@ -8,12 +8,12 @@ import (
 	"sync"
 	"time"
 
+	loggingclient "code.cloudfoundry.org/diego-logging-client"
 	"code.cloudfoundry.org/executor"
 	"code.cloudfoundry.org/executor/depot/event"
 	"code.cloudfoundry.org/executor/depot/transformer"
 	"code.cloudfoundry.org/garden"
 	"code.cloudfoundry.org/garden/server"
-	loggregator_v2 "code.cloudfoundry.org/go-loggregator/compatibility"
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/volman"
 	"github.com/tedsuo/ifrit"
@@ -39,7 +39,7 @@ const (
 type storeNode struct {
 	modifiedIndex               uint
 	hostTrustedCertificatesPath string
-	metronClient                loggregator_v2.IngressClient
+	metronClient                loggingclient.IngressClient
 
 	// infoLock protects modifying info and swapping gardenContainer pointers
 	infoLock           *sync.Mutex
@@ -72,7 +72,7 @@ func newStoreNode(
 	eventEmitter event.Hub,
 	transformer transformer.Transformer,
 	hostTrustedCertificatesPath string,
-	metronClient loggregator_v2.IngressClient,
+	metronClient loggingclient.IngressClient,
 ) *storeNode {
 	return &storeNode{
 		config:                      config,
@@ -541,7 +541,7 @@ func (n *storeNode) complete(logger lager.Logger, failed bool, failureReason str
 	go n.eventEmitter.Emit(executor.NewContainerCompleteEvent(n.info))
 }
 
-func sendMetricDuration(logger lager.Logger, metric string, value time.Duration, metronClient loggregator_v2.IngressClient) {
+func sendMetricDuration(logger lager.Logger, metric string, value time.Duration, metronClient loggingclient.IngressClient) {
 	err := metronClient.SendDuration(metric, value)
 	if err != nil {
 		switch metric {
@@ -561,7 +561,7 @@ func sendMetricDuration(logger lager.Logger, metric string, value time.Duration,
 	}
 }
 
-func createContainer(logger lager.Logger, spec garden.ContainerSpec, client garden.Client, metronClient loggregator_v2.IngressClient) (garden.Container, error) {
+func createContainer(logger lager.Logger, spec garden.ContainerSpec, client garden.Client, metronClient loggingclient.IngressClient) (garden.Container, error) {
 	logger.Info("creating-container-in-garden")
 	startTime := time.Now()
 	container, err := client.Create(spec)

--- a/depot/log_streamer/log_streamer.go
+++ b/depot/log_streamer/log_streamer.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"strconv"
 
-	loggregator_v2 "code.cloudfoundry.org/go-loggregator/compatibility"
+	loggingclient "code.cloudfoundry.org/diego-logging-client"
 
 	"github.com/cloudfoundry/sonde-go/events"
 )
@@ -31,7 +31,7 @@ type logStreamer struct {
 	stderr *streamDestination
 }
 
-func New(guid string, sourceName string, index int, metronClient loggregator_v2.IngressClient) LogStreamer {
+func New(guid string, sourceName string, index int, metronClient loggingclient.IngressClient) LogStreamer {
 	if guid == "" {
 		return noopStreamer{}
 	}

--- a/depot/log_streamer/log_streamer_test.go
+++ b/depot/log_streamer/log_streamer_test.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"sync"
 
+	mfakes "code.cloudfoundry.org/diego-logging-client/testhelpers"
 	"code.cloudfoundry.org/executor/depot/log_streamer"
-	mfakes "code.cloudfoundry.org/go-loggregator/testhelpers/fakes/v1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 

--- a/depot/log_streamer/stream_destination.go
+++ b/depot/log_streamer/stream_destination.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 	"unicode/utf8"
 
-	loggregator_v2 "code.cloudfoundry.org/go-loggregator/compatibility"
+	loggingclient "code.cloudfoundry.org/diego-logging-client"
 
 	"github.com/cloudfoundry/sonde-go/events"
 )
@@ -16,10 +16,10 @@ type streamDestination struct {
 	messageType  events.LogMessage_MessageType
 	buffer       []byte
 	processLock  sync.Mutex
-	metronClient loggregator_v2.IngressClient
+	metronClient loggingclient.IngressClient
 }
 
-func newStreamDestination(guid, sourceName, sourceId string, messageType events.LogMessage_MessageType, metronClient loggregator_v2.IngressClient) *streamDestination {
+func newStreamDestination(guid, sourceName, sourceId string, messageType events.LogMessage_MessageType, metronClient loggingclient.IngressClient) *streamDestination {
 	return &streamDestination{
 		guid:         guid,
 		sourceName:   sourceName,

--- a/depot/metrics/reporter.go
+++ b/depot/metrics/reporter.go
@@ -5,8 +5,8 @@ import (
 	"time"
 
 	"code.cloudfoundry.org/clock"
+	loggingclient "code.cloudfoundry.org/diego-logging-client"
 	"code.cloudfoundry.org/executor"
-	loggregator_v2 "code.cloudfoundry.org/go-loggregator/compatibility"
 	"code.cloudfoundry.org/lager"
 )
 
@@ -34,7 +34,7 @@ type Reporter struct {
 	ExecutorSource ExecutorSource
 	Clock          clock.Clock
 	Logger         lager.Logger
-	MetronClient   loggregator_v2.IngressClient
+	MetronClient   loggingclient.IngressClient
 }
 
 func (reporter *Reporter) Run(signals <-chan os.Signal, ready chan<- struct{}) error {

--- a/depot/metrics/reporter_test.go
+++ b/depot/metrics/reporter_test.go
@@ -10,10 +10,10 @@ import (
 	. "github.com/onsi/gomega"
 
 	"code.cloudfoundry.org/clock/fakeclock"
+	mfakes "code.cloudfoundry.org/diego-logging-client/testhelpers"
 	"code.cloudfoundry.org/executor"
 	"code.cloudfoundry.org/executor/depot/metrics"
 	"code.cloudfoundry.org/executor/fakes"
-	mfakes "code.cloudfoundry.org/go-loggregator/testhelpers/fakes/v1"
 	"code.cloudfoundry.org/lager/lagertest"
 	"github.com/tedsuo/ifrit"
 )

--- a/depot/transformer/transformer_test.go
+++ b/depot/transformer/transformer_test.go
@@ -10,12 +10,12 @@ import (
 
 	"code.cloudfoundry.org/bbs/models"
 	"code.cloudfoundry.org/clock/fakeclock"
+	mfakes "code.cloudfoundry.org/diego-logging-client/testhelpers"
 	"code.cloudfoundry.org/executor"
 	"code.cloudfoundry.org/executor/depot/log_streamer"
 	"code.cloudfoundry.org/executor/depot/transformer"
 	"code.cloudfoundry.org/garden"
 	"code.cloudfoundry.org/garden/gardenfakes"
-	mfakes "code.cloudfoundry.org/go-loggregator/testhelpers/fakes/v1"
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/lager/lagertest"
 	"code.cloudfoundry.org/workpool"

--- a/gardenhealth/runner.go
+++ b/gardenhealth/runner.go
@@ -5,8 +5,8 @@ import (
 	"time"
 
 	"code.cloudfoundry.org/clock"
+	loggingclient "code.cloudfoundry.org/diego-logging-client"
 	"code.cloudfoundry.org/executor"
-	loggregator_v2 "code.cloudfoundry.org/go-loggregator/compatibility"
 	"code.cloudfoundry.org/lager"
 )
 
@@ -31,7 +31,7 @@ type Runner struct {
 	logger           lager.Logger
 	checker          Checker
 	executorClient   executor.Client
-	metronClient     loggregator_v2.IngressClient
+	metronClient     loggingclient.IngressClient
 	clock            clock.Clock
 }
 
@@ -47,7 +47,7 @@ func NewRunner(
 	logger lager.Logger,
 	checker Checker,
 	executorClient executor.Client,
-	metronClient loggregator_v2.IngressClient,
+	metronClient loggingclient.IngressClient,
 	clock clock.Clock,
 ) *Runner {
 	return &Runner{

--- a/gardenhealth/runner_test.go
+++ b/gardenhealth/runner_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/tedsuo/ifrit/ginkgomon"
 
 	"code.cloudfoundry.org/clock/fakeclock"
+	mfakes "code.cloudfoundry.org/diego-logging-client/testhelpers"
 	fakeexecutor "code.cloudfoundry.org/executor/fakes"
 	"code.cloudfoundry.org/executor/gardenhealth/fakegardenhealth"
-	mfakes "code.cloudfoundry.org/go-loggregator/testhelpers/fakes/v1"
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/lager/lagertest"
 

--- a/initializer/initializer.go
+++ b/initializer/initializer.go
@@ -19,6 +19,7 @@ import (
 	"code.cloudfoundry.org/cacheddownloader"
 	"code.cloudfoundry.org/cfhttp"
 	"code.cloudfoundry.org/clock"
+	loggingclient "code.cloudfoundry.org/diego-logging-client"
 	"code.cloudfoundry.org/durationjson"
 	"code.cloudfoundry.org/executor"
 	"code.cloudfoundry.org/executor/containermetrics"
@@ -34,7 +35,6 @@ import (
 	"code.cloudfoundry.org/garden"
 	GardenClient "code.cloudfoundry.org/garden/client"
 	GardenConnection "code.cloudfoundry.org/garden/client/connection"
-	loggregator_v2 "code.cloudfoundry.org/go-loggregator/compatibility"
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/systemcerts"
 	"code.cloudfoundry.org/volman/vollocal"
@@ -172,7 +172,7 @@ var DefaultConfiguration = ExecutorConfig{
 	ContainerMetricsReportInterval:     durationjson.Duration(15 * time.Second),
 }
 
-func Initialize(logger lager.Logger, config ExecutorConfig, gardenHealthcheckRootFS string, metronClient loggregator_v2.IngressClient, clock clock.Clock) (executor.Client, grouper.Members, error) {
+func Initialize(logger lager.Logger, config ExecutorConfig, gardenHealthcheckRootFS string, metronClient loggingclient.IngressClient, clock clock.Clock) (executor.Client, grouper.Members, error) {
 	postSetupHook, err := shlex.Split(config.PostSetupHook)
 	if err != nil {
 		logger.Error("failed-to-parse-post-setup-hook", err)
@@ -348,7 +348,7 @@ func Initialize(logger lager.Logger, config ExecutorConfig, gardenHealthcheckRoo
 // Until we get a successful response from garden,
 // periodically emit metrics saying how long we've been trying
 // while retrying the connection indefinitely.
-func waitForGarden(logger lager.Logger, gardenClient GardenClient.Client, metronClient loggregator_v2.IngressClient, clock clock.Clock) error {
+func waitForGarden(logger lager.Logger, gardenClient GardenClient.Client, metronClient loggingclient.IngressClient, clock clock.Clock) error {
 	pingStart := clock.Now()
 	logger = logger.Session("wait-for-garden", lager.Data{"initialTime:": pingStart})
 	pingRequest := clock.NewTimer(0)
@@ -544,7 +544,7 @@ func TLSConfigFromConfig(logger lager.Logger, certsRetriever CertPoolRetriever, 
 	return tlsConfig, nil
 }
 
-func CredManagerFromConfig(logger lager.Logger, metronClient loggregator_v2.IngressClient, config ExecutorConfig, clock clock.Clock) (containerstore.CredManager, error) {
+func CredManagerFromConfig(logger lager.Logger, metronClient loggingclient.IngressClient, config ExecutorConfig, clock clock.Clock) (containerstore.CredManager, error) {
 	if config.InstanceIdentityCredDir != "" {
 		logger.Info("instance-identity-enabled")
 		keyData, err := ioutil.ReadFile(config.InstanceIdentityPrivateKeyPath)

--- a/initializer/initializer_test.go
+++ b/initializer/initializer_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"code.cloudfoundry.org/clock/fakeclock"
+	mfakes "code.cloudfoundry.org/diego-logging-client/testhelpers"
 	"code.cloudfoundry.org/durationjson"
 	"code.cloudfoundry.org/executor"
 	"code.cloudfoundry.org/executor/depot/containerstore"
@@ -20,7 +21,6 @@ import (
 	"code.cloudfoundry.org/executor/initializer/configuration"
 	"code.cloudfoundry.org/executor/initializer/fakes"
 	"code.cloudfoundry.org/garden"
-	mfakes "code.cloudfoundry.org/go-loggregator/testhelpers/fakes/v1"
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/lager/lagertest"
 	. "github.com/onsi/ginkgo"


### PR DESCRIPTION
This work upgrades Diego to use go-loggregator v3.0.0. It also encapsulates Diego's use of the loggregator client behind a single interface found in `diego-logging-client` within `diego-release`.

By wrapping go-loggregator in Diego, we ensure future upgrades to go-loggregator will not require such large change sets.

This PR goes hand in hand with the following PRs:
- [diego-release](https://github.com/cloudfoundry/diego-release/pull/349)
- [auctioneer](https://github.com/cloudfoundry/auctioneer/pull/6)
- [bbs](https://github.com/cloudfoundry/bbs/pull/24)
- [benchmarkbbs](https://github.com/cloudfoundry/benchmarkbbs/pull/3)
- [locket](https://github.com/cloudfoundry/locket/pull/3)
- [rep](https://github.com/cloudfoundry/rep/pull/17)
- [volman](https://github.com/cloudfoundry/volman/pull/4)

[#148451433]

Signed-off-by: Jason Keene <jkeene@pivotal.io>