### PR TITLE
Adds CPU.Weight = MemoryMB on container creation

### DIFF
--- a/depot/containerstore/containerstore.go
+++ b/depot/containerstore/containerstore.go
@@ -55,6 +55,7 @@ type ContainerConfig struct {
 	OwnerName    string
 	INodeLimit   uint64
 	MaxCPUShares uint64
+	SetCPUWeight bool
 
 	ReservedExpirationTime time.Duration
 	ReapInterval           time.Duration

--- a/depot/containerstore/storenode.go
+++ b/depot/containerstore/storenode.go
@@ -352,6 +352,10 @@ func (n *storeNode) createGardenContainer(logger lager.Logger, info *executor.Co
 		NetOut:     netOutRules,
 	}
 
+	if n.config.SetCPUWeight {
+		containerSpec.Limits.CPU.Weight = uint64(info.MemoryMB)
+	}
+
 	gardenContainer, err := createContainer(logger, containerSpec, n.gardenClient, n.metronClient)
 	if err != nil {
 		return nil, err

--- a/initializer/initializer.go
+++ b/initializer/initializer.go
@@ -82,6 +82,7 @@ type ExecutorConfig struct {
 	CachePath                          string                `json:"cache_path,omitempty"`
 	ContainerInodeLimit                uint64                `json:"container_inode_limit,omitempty"`
 	ContainerMaxCpuShares              uint64                `json:"container_max_cpu_shares,omitempty"`
+	SetCPUWeight                       bool                  `json:"set_cpu_weight,omitempty"`
 	ContainerMetricsReportInterval     durationjson.Duration `json:"container_metrics_report_interval,omitempty"`
 	ContainerOwnerName                 string                `json:"container_owner_name,omitempty"`
 	ContainerReapInterval              durationjson.Duration `json:"container_reap_interval,omitempty"`
@@ -272,6 +273,7 @@ func Initialize(logger lager.Logger, config ExecutorConfig, cellID string,
 		OwnerName:              config.ContainerOwnerName,
 		INodeLimit:             config.ContainerInodeLimit,
 		MaxCPUShares:           config.ContainerMaxCpuShares,
+		SetCPUWeight:           config.SetCPUWeight,
 		ReservedExpirationTime: time.Duration(config.ReservedExpirationTime),
 		ReapInterval:           time.Duration(config.ContainerReapInterval),
 	}


### PR DESCRIPTION
This is to allow garden to perform new CPU Sharing calculations based on the memory baseline rather than cloud controllers modified `CpuWeight` value. [Story](https://www.pivotaltracker.com/story/show/159227228)

For this to be bumped in `diego-release`, garden needs to be bumped to master (c01111c)

Co-authored-by: Oliver Stenbom <ostenbom@pivotal.io>

Signed-off-by: Julia Nedialkova <julianedialkova@hotmail.com>
Signed-off-by: Oliver Stenbom <ostenbom@pivotal.io>