### PR TITLE
Add Optional Support for Unique Volume IDs

### DIFF
--- a/depot/containerstore/containerstore_test.go
+++ b/depot/containerstore/containerstore_test.go
@@ -373,7 +373,7 @@ var _ = Describe("Container Store", func() {
 						Guid:  "metric-guid",
 						Index: 1,
 					},
-					Env: env,
+					Env:                           env,
 					TrustedSystemCertificatesPath: "",
 					Network: &executor.Network{
 						Properties: map[string]string{
@@ -714,7 +714,7 @@ var _ = Describe("Container Store", func() {
 
 					count := 0
 					volumeManager.MountStub = // first call mounts at a different point than second call
-						func(lager.Logger, string, string, map[string]interface{}) (volman.MountResponse, error) {
+						func(lager.Logger, string, string, string, map[string]interface{}) (volman.MountResponse, error) {
 							defer func() { count = count + 1 }()
 							if count == 0 {
 								return volman.MountResponse{Path: "hpath1"}, nil
@@ -728,14 +728,16 @@ var _ = Describe("Container Store", func() {
 					Expect(err).NotTo(HaveOccurred())
 					Expect(volumeManager.MountCallCount()).To(Equal(2))
 
-					_, driverName, volumeId, config := volumeManager.MountArgsForCall(0)
+					_, driverName, volumeId, containerId, config := volumeManager.MountArgsForCall(0)
 					Expect(driverName).To(Equal(runReq.VolumeMounts[0].Driver))
 					Expect(volumeId).To(Equal(runReq.VolumeMounts[0].VolumeId))
+					Expect(containerId).To(Equal(containerGuid))
 					Expect(config).To(Equal(runReq.VolumeMounts[0].Config))
 
-					_, driverName, volumeId, config = volumeManager.MountArgsForCall(1)
+					_, driverName, volumeId, containerId, config = volumeManager.MountArgsForCall(1)
 					Expect(driverName).To(Equal(runReq.VolumeMounts[1].Driver))
 					Expect(volumeId).To(Equal(runReq.VolumeMounts[1].VolumeId))
+					Expect(containerId).To(Equal(containerGuid))
 					Expect(config).To(Equal(runReq.VolumeMounts[1].Config))
 				})
 
@@ -2001,7 +2003,7 @@ var _ = Describe("Container Store", func() {
 				}
 				count := 0
 				volumeManager.MountStub = // first call mounts at a different point than second call
-					func(lager.Logger, string, string, map[string]interface{}) (volman.MountResponse, error) {
+					func(lager.Logger, string, string, string, map[string]interface{}) (volman.MountResponse, error) {
 						defer func() { count = count + 1 }()
 						if count == 0 {
 							return volman.MountResponse{Path: "hpath1"}, nil
@@ -2015,13 +2017,15 @@ var _ = Describe("Container Store", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(volumeManager.UnmountCallCount()).To(Equal(2))
 
-				_, driverId, volumeId := volumeManager.UnmountArgsForCall(0)
+				_, driverId, volumeId, containerId := volumeManager.UnmountArgsForCall(0)
 				Expect(driverId).To(Equal(runReq.RunInfo.VolumeMounts[0].Driver))
 				Expect(volumeId).To(Equal(runReq.RunInfo.VolumeMounts[0].VolumeId))
+				Expect(containerId).To(Equal(containerGuid))
 
-				_, driverId, volumeId = volumeManager.UnmountArgsForCall(1)
+				_, driverId, volumeId, containerId = volumeManager.UnmountArgsForCall(1)
 				Expect(driverId).To(Equal(runReq.RunInfo.VolumeMounts[1].Driver))
 				Expect(volumeId).To(Equal(runReq.RunInfo.VolumeMounts[1].VolumeId))
+				Expect(containerId).To(Equal(containerGuid))
 			})
 
 			Context("when we fail to release cache dependencies", func() {
@@ -2033,13 +2037,15 @@ var _ = Describe("Container Store", func() {
 					Expect(err).To(HaveOccurred())
 					Expect(volumeManager.UnmountCallCount()).To(Equal(2))
 
-					_, driverId, volumeId := volumeManager.UnmountArgsForCall(0)
+					_, driverId, volumeId, containerId := volumeManager.UnmountArgsForCall(0)
 					Expect(driverId).To(Equal(runReq.RunInfo.VolumeMounts[0].Driver))
 					Expect(volumeId).To(Equal(runReq.RunInfo.VolumeMounts[0].VolumeId))
+					Expect(containerId).To(Equal(containerGuid))
 
-					_, driverId, volumeId = volumeManager.UnmountArgsForCall(1)
+					_, driverId, volumeId, containerId = volumeManager.UnmountArgsForCall(1)
 					Expect(driverId).To(Equal(runReq.RunInfo.VolumeMounts[1].Driver))
 					Expect(volumeId).To(Equal(runReq.RunInfo.VolumeMounts[1].VolumeId))
+					Expect(containerId).To(Equal(containerGuid))
 				})
 			})
 			Context("when an volume unmount fails", func() {
@@ -2426,7 +2432,7 @@ var _ = Describe("Container Store", func() {
 				Guid:  "metric-guid",
 				Index: 1,
 			},
-			Env: []executor.EnvironmentVariable{},
+			Env:                           []executor.EnvironmentVariable{},
 			TrustedSystemCertificatesPath: "",
 			Network: &executor.Network{
 				Properties: map[string]string{},

--- a/depot/containerstore/storenode.go
+++ b/depot/containerstore/storenode.go
@@ -248,7 +248,7 @@ func (n *storeNode) Create(logger lager.Logger) error {
 func (n *storeNode) mountVolumes(logger lager.Logger, info executor.Container) ([]garden.BindMount, error) {
 	gardenMounts := []garden.BindMount{}
 	for _, volume := range info.VolumeMounts {
-		hostMount, err := n.volumeManager.Mount(logger, volume.Driver, volume.VolumeId, volume.Config)
+		hostMount, err := n.volumeManager.Mount(logger, volume.Driver, volume.VolumeId, info.Guid, volume.Config)
 		if err != nil {
 			return nil, err
 		}
@@ -594,7 +594,7 @@ func (n *storeNode) Destroy(logger lager.Logger) error {
 	}
 
 	for _, volume := range info.VolumeMounts {
-		err = n.volumeManager.Unmount(logger, volume.Driver, volume.VolumeId)
+		err = n.volumeManager.Unmount(logger, volume.Driver, volume.VolumeId, info.Guid)
 		if err != nil {
 			logger.Error("failed-to-unmount-volume", err)
 			bindMountCleanupErr = errors.New(BindMountCleanupFailed)


### PR DESCRIPTION
This PR updates the executor volmanager mount/unmount calls to optionally include the container ID so that volmanager can create unique separate mounts per container (based on whether the driver opts into unique volumes or not).

See [#160356605](https://www.pivotaltracker.com/story/show/160356605) for context.

Related changes that are required when bumping executor in diego-release:
- csiplugin: bump to https://github.com/cloudfoundry/csiplugin/commit/4f2f30acf8ab21411d2884801b03d0d88aa676d7
- inigo: merge https://github.com/cloudfoundry/inigo/pull/19 and bump
- localdriver: bump to https://github.com/cloudfoundry/localdriver/commit/4bfa18563f43a6a072fb53da9f424fa91605034d
- voldriver: bump to https://github.com/cloudfoundry/voldriver/commit/dc3d1851f471e0dc0bd4cfdffcabe60a446dd72c
- volman: bump to https://github.com/cloudfoundry/volman/commit/67594698ff9b237f79fbbc69afb6d536d061fbd6

Please let us know if you have any questions.

Thanks,
Dave and @mariash 