### PR TITLE
Ensure volumes get unmounted even when garden fails to destroy the container

### DIFF
--- a/depot/containerstore/containerstore_test.go
+++ b/depot/containerstore/containerstore_test.go
@@ -2055,7 +2055,17 @@ var _ = Describe("Container Store", func() {
 
 				It("still attempts to unmount the remaining volumes", func() {
 					err := containerStore.Destroy(logger, containerGuid)
-					Expect(err).To(HaveOccurred())
+					Expect(err).NotTo(HaveOccurred())
+					Expect(volumeManager.UnmountCallCount()).To(Equal(2))
+				})
+			})
+			Context("when garden fails to destroy the container", func() {
+				BeforeEach(func() {
+					gardenClient.DestroyReturns(errors.New("destroy failed"))
+				})
+				It("should still unmount the volumes", func() {
+					err := containerStore.Destroy(logger, containerGuid)
+					Expect(err).To(MatchError("destroy failed"))
 					Expect(volumeManager.UnmountCallCount()).To(Equal(2))
 				})
 			})


### PR DESCRIPTION
Hi,

This PR defers the volume unmount logic to ensure that it still runs in the case that garden fails to destroy the container. One side-effect of this change is that Destroy() no longer returns an error if unmounting a volume fails. Instead, the error is logged and no error is returned. We have run the unit tests and the volman inigo suite to confirm that this change works as expected.

Please see https://www.pivotaltracker.com/story/show/161137404 for more details. Let us know if you have any questions.

Thanks,
Paul and @davewalter 

CC @julian-hj @mariash 