### PR TITLE
configure Envoy to use filesystem SDS

### DIFF
--- a/depot/containerstore/envoy/envoy.go
+++ b/depot/containerstore/envoy/envoy.go
@@ -24,10 +24,19 @@ type CertificateValidationContext struct {
 	VerifySubjectAltName []string   `yaml:"verify_subject_alt_name,omitempty"`
 }
 
+type SDSConfig struct {
+	Path string `yaml:"path"`
+}
+
+type SecretConfig struct {
+	Name      string    `yaml:"name"`
+	SDSConfig SDSConfig `yaml:"sds_config"`
+}
+
 type CommonTLSContext struct {
-	TLSCertificates   []TLSCertificate             `yaml:"tls_certificates"`
-	TLSParams         TLSParams                    `yaml:"tls_params"`
-	ValidationContext CertificateValidationContext `yaml:"validation_context"`
+	TLSCertificateSDSSecretConfigs   SecretConfig `yaml:"tls_certificate_sds_secret_configs"`
+	ValidationContextSDSSecretConfig SecretConfig `yaml:"validation_context_sds_secret_config,omitempty"`
+	TLSParams                        TLSParams    `yaml:"tls_params"`
 }
 
 type TLSParams struct {
@@ -44,16 +53,10 @@ type FilterChain struct {
 	TLSContext TLSContext `yaml:"tls_context"`
 }
 
-type Resource struct {
-	Type         string        `yaml:"@type"`
+type Listener struct {
 	Name         string        `yaml:"name"`
 	Address      Address       `yaml:"address"`
 	FilterChains []FilterChain `yaml:"filter_chains"`
-}
-
-type ListenerConfig struct {
-	VersionInfo string     `yaml:"version_info"`
-	Resources   []Resource `yaml:"resources"`
 }
 
 type SocketAddress struct {
@@ -88,7 +91,8 @@ type Cluster struct {
 }
 
 type StaticResources struct {
-	Clusters []Cluster `yaml:"clusters"`
+	Clusters  []Cluster  `yaml:"clusters"`
+	Listeners []Listener `yaml:"listeners"`
 }
 
 type LDSConfig struct {
@@ -100,7 +104,28 @@ type DynamicResources struct {
 }
 
 type ProxyConfig struct {
-	Admin            Admin            `yaml:"admin"`
-	StaticResources  StaticResources  `yaml:"static_resources"`
-	DynamicResources DynamicResources `yaml:"dynamic_resources"`
+	Admin           Admin           `yaml:"admin"`
+	StaticResources StaticResources `yaml:"static_resources"`
+}
+
+type CAResource struct {
+	Type              string                       `yaml:"@type"`
+	Name              string                       `yaml:"name"`
+	ValidationContext CertificateValidationContext `yaml:"validation_context"`
+}
+
+type SDSCAResource struct {
+	VersionInfo string       `yaml:"version_info"`
+	Resources   []CAResource `yaml:"resources"`
+}
+
+type CertificateResource struct {
+	Type           string         `yaml:"@type"`
+	Name           string         `yaml:"name"`
+	TLSCertificate TLSCertificate `yaml:"tls_certificate"`
+}
+
+type SDSCertificateResource struct {
+	VersionInfo string                `yaml:"version_info"`
+	Resources   []CertificateResource `yaml:"resources"`
 }


### PR DESCRIPTION
For cf-networking story [#161008066](https://www.pivotaltracker.com/story/show/161008066)

In order to support route integrity and our work, we will eventually want Envoy to be configured by two sources. The route integrity should be configured by the Secret Discovery Service and the c2c proxying will be configured via ADS (not part of this story). Currently route integrity is configured by Diego by a way that makes configuring with ADS not possible.

This PR updates the generated envoy.yaml to use static listeners.

Note: This can be merged now. But should not be bumped in diego-release until [#160455694](https://www.pivotaltracker.com/n/projects/1003146/stories/160455694) is completed