### PR TITLE
Get envoy to receive dynamic config from pilot

### DIFF
--- a/depot/containerstore/envoy/envoy.go
+++ b/depot/containerstore/envoy/envoy.go
@@ -81,13 +81,17 @@ type CircuitBreakers struct {
 	Thresholds []Threshold `yamls:"thresholds"`
 }
 
+type HTTP2ProtocolOptions struct {
+}
+
 type Cluster struct {
-	Name              string          `yaml:"name"`
-	ConnectionTimeout string          `yaml:"connect_timeout"`
-	Type              string          `yaml:"type"`
-	LbPolicy          string          `yaml:"lb_policy"`
-	Hosts             []Address       `yaml:"hosts"`
-	CircuitBreakers   CircuitBreakers `yaml:"circuit_breakers"`
+	Name                 string               `yaml:"name"`
+	ConnectionTimeout    string               `yaml:"connect_timeout"`
+	Type                 string               `yaml:"type"`
+	LbPolicy             string               `yaml:"lb_policy"`
+	Hosts                []Address            `yaml:"hosts"`
+	CircuitBreakers      CircuitBreakers      `yaml:"circuit_breakers"`
+	HTTP2ProtocolOptions HTTP2ProtocolOptions `yaml:"http2_protocol_options"`
 }
 
 type StaticResources struct {
@@ -95,17 +99,39 @@ type StaticResources struct {
 	Listeners []Listener `yaml:"listeners"`
 }
 
+type ADS struct{}
+
 type LDSConfig struct {
-	Path string `yaml:"path"`
+	ADS ADS `yaml:"ads"`
+}
+
+type CDSConfig struct {
+	ADS ADS `yaml:"ads"`
+}
+
+type ADSConfig struct {
+	APIType      string       `yaml:"api_type"`
+	GRPCServices GRPCServices `yaml:"grpc_services"`
+}
+
+type GRPCServices struct {
+	EnvoyGRPC EnvoyGRPC `yaml:"envoy_grpc"`
+}
+
+type EnvoyGRPC struct {
+	ClusterName string `yaml:"cluster_name"`
 }
 
 type DynamicResources struct {
 	LDSConfig LDSConfig `yaml:"lds_config"`
+	CDSConfig CDSConfig `yaml:"cds_config"`
+	ADSConfig ADSConfig `yaml:"ads_config"`
 }
 
 type ProxyConfig struct {
-	Admin           Admin           `yaml:"admin"`
-	StaticResources StaticResources `yaml:"static_resources"`
+	Admin            Admin             `yaml:"admin"`
+	StaticResources  StaticResources   `yaml:"static_resources"`
+	DynamicResources *DynamicResources `yaml:"dynamic_resources,omitempty"`
 }
 
 type CAResource struct {

--- a/depot/containerstore/envoy/envoy.go
+++ b/depot/containerstore/envoy/envoy.go
@@ -24,10 +24,19 @@ type CertificateValidationContext struct {
 	VerifySubjectAltName []string   `yaml:"verify_subject_alt_name,omitempty"`
 }
 
+type SDSConfig struct {
+	Path string `yaml:"path"`
+}
+
+type SecretConfig struct {
+	Name      string    `yaml:"name"`
+	SDSConfig SDSConfig `yaml:"sds_config"`
+}
+
 type CommonTLSContext struct {
-	TLSCertificates   []TLSCertificate             `yaml:"tls_certificates"`
-	TLSParams         TLSParams                    `yaml:"tls_params"`
-	ValidationContext CertificateValidationContext `yaml:"validation_context"`
+	TLSCertificateSDSSecretConfigs   SecretConfig `yaml:"tls_certificate_sds_secret_configs"`
+	ValidationContextSDSSecretConfig SecretConfig `yaml:"validation_context_sds_secret_config,omitempty"`
+	TLSParams                        TLSParams    `yaml:"tls_params"`
 }
 
 type TLSParams struct {
@@ -44,16 +53,10 @@ type FilterChain struct {
 	TLSContext TLSContext `yaml:"tls_context"`
 }
 
-type Resource struct {
-	Type         string        `yaml:"@type"`
+type Listener struct {
 	Name         string        `yaml:"name"`
 	Address      Address       `yaml:"address"`
 	FilterChains []FilterChain `yaml:"filter_chains"`
-}
-
-type ListenerConfig struct {
-	VersionInfo string     `yaml:"version_info"`
-	Resources   []Resource `yaml:"resources"`
 }
 
 type SocketAddress struct {
@@ -88,7 +91,8 @@ type Cluster struct {
 }
 
 type StaticResources struct {
-	Clusters []Cluster `yaml:"clusters"`
+	Clusters  []Cluster  `yaml:"clusters"`
+	Listeners []Listener `yaml:"listeners"`
 }
 
 type LDSConfig struct {
@@ -100,7 +104,28 @@ type DynamicResources struct {
 }
 
 type ProxyConfig struct {
-	Admin            Admin            `yaml:"admin"`
-	StaticResources  StaticResources  `yaml:"static_resources"`
-	DynamicResources DynamicResources `yaml:"dynamic_resources"`
+	Admin           Admin           `yaml:"admin"`
+	StaticResources StaticResources `yaml:"static_resources"`
+}
+
+type CAResource struct {
+	Type              string                       `yaml:"@type"`
+	Name              string                       `yaml:"name"`
+	ValidationContext CertificateValidationContext `yaml:"validation_context"`
+}
+
+type SDSCAResource struct {
+	VersionInfo string       `yaml:"version_info"`
+	Resources   []CAResource `yaml:"resources"`
+}
+
+type CertificateResource struct {
+	Type           string         `yaml:"@type"`
+	Name           string         `yaml:"name"`
+	TLSCertificate TLSCertificate `yaml:"tls_certificate"`
+}
+
+type SDSCertificateResource struct {
+	VersionInfo string                `yaml:"version_info"`
+	Resources   []CertificateResource `yaml:"resources"`
 }

--- a/depot/containerstore/proxy_config_handler.go
+++ b/depot/containerstore/proxy_config_handler.go
@@ -9,6 +9,8 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/tedsuo/ifrit"
@@ -65,6 +67,8 @@ type ProxyConfigHandler struct {
 
 	reloadDuration time.Duration
 	reloadClock    clock.Clock
+
+	adsServers []string
 }
 
 type NoopProxyConfigHandler struct{}
@@ -107,6 +111,7 @@ func NewProxyConfigHandler(
 	containerProxyRequireClientCerts bool,
 	reloadDuration time.Duration,
 	reloadClock clock.Clock,
+	adsServers []string,
 ) *ProxyConfigHandler {
 	return &ProxyConfigHandler{
 		logger:                             logger.Session("proxy-manager"),
@@ -117,6 +122,7 @@ func NewProxyConfigHandler(
 		containerProxyRequireClientCerts:   containerProxyRequireClientCerts,
 		reloadDuration:                     reloadDuration,
 		reloadClock:                        reloadClock,
+		adsServers:                         adsServers,
 	}
 }
 
@@ -229,7 +235,10 @@ func (p *ProxyConfigHandler) writeConfig(credentials Credential, container execu
 		return err
 	}
 
-	proxyConfig := generateProxyConfig(container, adminPort, p.containerProxyRequireClientCerts)
+	proxyConfig, err := generateProxyConfig(container, adminPort, p.containerProxyRequireClientCerts, p.adsServers)
+	if err != nil {
+		return err
+	}
 
 	err = writeProxyConfig(proxyConfig, proxyConfigPath)
 	if err != nil {
@@ -254,7 +263,7 @@ func (p *ProxyConfigHandler) writeConfig(credentials Credential, container execu
 	return nil
 }
 
-func generateProxyConfig(container executor.Container, adminPort uint16, requireClientCerts bool) envoy.ProxyConfig {
+func generateProxyConfig(container executor.Container, adminPort uint16, requireClientCerts bool, adsServers []string) (envoy.ProxyConfig, error) {
 	clusters := []envoy.Cluster{}
 	for index, portMap := range container.Ports {
 		clusterName := fmt.Sprintf("%d-service-cluster", index)
@@ -283,11 +292,64 @@ func generateProxyConfig(container executor.Container, adminPort uint16, require
 			},
 		},
 		StaticResources: envoy.StaticResources{
-			Clusters:  clusters,
 			Listeners: generateListeners(container, requireClientCerts),
 		},
 	}
-	return config
+
+	if len(adsServers) > 0 {
+		hosts := []envoy.Address{}
+		for _, a := range adsServers {
+			address, port, err := splitHost(a)
+			if err != nil {
+				return envoy.ProxyConfig{}, err
+			}
+			hosts = append(hosts, envoy.Address{SocketAddress: envoy.SocketAddress{Address: address, PortValue: port}})
+		}
+
+		clusters = append(clusters, envoy.Cluster{
+			Name:                 "pilot-ads",
+			ConnectionTimeout:    TimeOut,
+			Type:                 Static,
+			LbPolicy:             RoundRobin,
+			Hosts:                hosts,
+			HTTP2ProtocolOptions: envoy.HTTP2ProtocolOptions{},
+		})
+
+		dynamicResources := &envoy.DynamicResources{
+			LDSConfig: envoy.LDSConfig{
+				ADS: envoy.ADS{},
+			},
+			CDSConfig: envoy.CDSConfig{
+				ADS: envoy.ADS{},
+			},
+			ADSConfig: envoy.ADSConfig{
+				APIType: "GRPC",
+				GRPCServices: envoy.GRPCServices{
+					EnvoyGRPC: envoy.EnvoyGRPC{
+						ClusterName: "pilot-ads",
+					},
+				},
+			},
+		}
+		config.DynamicResources = dynamicResources
+	}
+
+	config.StaticResources.Clusters = clusters
+
+	return config, nil
+}
+
+func splitHost(host string) (string, uint16, error) {
+	parts := strings.Split(host, ":")
+	if len(parts) != 2 {
+		return "", 0, fmt.Errorf("ads server address is invalid: %s", host)
+	}
+
+	port, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return "", 0, fmt.Errorf("ads server address is invalid: %s", host)
+	}
+	return parts[0], uint16(port), nil
 }
 
 func writeProxyConfig(proxyConfig envoy.ProxyConfig, path string) error {

--- a/depot/transformer/transformer.go
+++ b/depot/transformer/transformer.go
@@ -714,7 +714,8 @@ func (t *transformer) transformContainerProxyStep(
 	bindMounts []garden.BindMount,
 ) ifrit.Runner {
 
-	envoyCMD := fmt.Sprintf("trap 'kill -9 0' TERM; /etc/cf-assets/envoy/envoy -c /etc/cf-assets/envoy_config/envoy.yaml --service-cluster proxy-cluster --service-node proxy-node --drain-time-s %d --log-level critical& pid=$!; wait $pid", int(t.drainWait.Seconds()))
+	envoyCMD := fmt.Sprintf("trap 'kill -9 0' TERM; /etc/cf-assets/envoy/envoy -c /etc/cf-assets/envoy_config/envoy.yaml --v2-config-only --service-cluster proxy-cluster --service-node sidecar~%s~x~x --drain-time-s %d --log-level critical& pid=$!; wait $pid", execContainer.InternalIP, int(t.drainWait.Seconds()))
+
 	args := []string{
 		"-c",
 		// make sure the entire process group is killed if the shell exits

--- a/depot/transformer/transformer_test.go
+++ b/depot/transformer/transformer_test.go
@@ -318,7 +318,7 @@ var _ = Describe("Transformer", func() {
 					Path: "sh",
 					Args: []string{
 						"-c",
-						"trap 'kill -9 0' TERM; /etc/cf-assets/envoy/envoy -c /etc/cf-assets/envoy_config/envoy.yaml --service-cluster proxy-cluster --service-node proxy-node --drain-time-s 1 --log-level critical& pid=$!; wait $pid",
+						"trap 'kill -9 0' TERM; /etc/cf-assets/envoy/envoy -c /etc/cf-assets/envoy_config/envoy.yaml --v2-config-only --service-cluster proxy-cluster --service-node sidecar~11.0.0.1~x~x --drain-time-s 1 --log-level critical& pid=$!; wait $pid",
 					},
 
 					Env: []string{
@@ -388,7 +388,7 @@ var _ = Describe("Transformer", func() {
 						Path: "sh",
 						Args: []string{
 							"-c",
-							"trap 'kill -9 0' TERM; /etc/cf-assets/envoy/envoy -c /etc/cf-assets/envoy_config/envoy.yaml --service-cluster proxy-cluster --service-node proxy-node --drain-time-s 1 --log-level critical& pid=$!; wait $pid",
+							"trap 'kill -9 0' TERM; /etc/cf-assets/envoy/envoy -c /etc/cf-assets/envoy_config/envoy.yaml --v2-config-only --service-cluster proxy-cluster --service-node sidecar~11.0.0.1~x~x --drain-time-s 1 --log-level critical& pid=$!; wait $pid",
 						},
 
 						Env: []string{

--- a/initializer/initializer.go
+++ b/initializer/initializer.go
@@ -102,6 +102,7 @@ type ExecutorConfig struct {
 	ContainerProxyTrustedCACerts       []string              `json:"container_proxy_trusted_ca_certs"`
 	ContainerProxyVerifySubjectAltName []string              `json:"container_proxy_verify_subject_alt_name"`
 	ContainerProxyRequireClientCerts   bool                  `json:"container_proxy_require_and_verify_client_certs"`
+	ContainerProxyADSServers           []string              `json:"container_proxy_ads_servers,omitempty"`
 	ExportNetworkEnvVars               bool                  `json:"export_network_env_vars,omitempty"` // DEPRECATED. Kept around for dusts compatability
 	GardenAddr                         string                `json:"garden_addr,omitempty"`
 	GardenHealthcheckCommandRetryPause durationjson.Duration `json:"garden_healthcheck_command_retry_pause,omitempty"`
@@ -275,6 +276,7 @@ func Initialize(logger lager.Logger, config ExecutorConfig, cellID string,
 			config.ContainerProxyRequireClientCerts,
 			time.Duration(config.EnvoyConfigReloadDuration),
 			clock,
+			config.ContainerProxyADSServers,
 		)
 	} else {
 		proxyConfigHandler = containerstore.NewNoopProxyConfigHandler()

--- a/initializer/initializer_test.go
+++ b/initializer/initializer_test.go
@@ -74,6 +74,7 @@ var _ = Describe("Initializer", func() {
 			DiskMB:                         configuration.Automatic,
 			EnableDeclarativeHealthcheck:       false,
 			EnableContainerProxy:               false,
+			ContainerProxyADSServers:           []string{"10.0.0.2:15010"},
 			GardenAddr:                         "/tmp/garden.sock",
 			GardenHealthcheckCommandRetryPause: durationjson.Duration(1 * time.Second),
 			GardenHealthcheckEmissionInterval:  durationjson.Duration(30 * time.Second),


### PR DESCRIPTION
Note: Merge this after https://github.com/cloudfoundry/executor/pull/39

We want the sidecar envoy to pull configuration from the Secret Discovery Service for route integrity (already done) and Pilot (this PR).

The operator must ensure the istio-control VM is network-accessible via ASG or dynamic egress rules.

