### PR TITLE
fix proxy service node id to be Istio-compatible

### DIFF
--- a/depot/containerstore/proxy_config_handler.go
+++ b/depot/containerstore/proxy_config_handler.go
@@ -325,6 +325,10 @@ func generateProxyConfig(
 			AccessLogPath: AdminAccessLog,
 			Address:       envoyAddr("127.0.0.1", adminPort),
 		},
+		Node: &envoy_v2_core.Node{
+			Id:      fmt.Sprintf("sidecar~%s~%s~x", container.InternalIP, container.Guid),
+			Cluster: "proxy-cluster",
+		},
 		StaticResources: &envoy_v2_bootstrap.Bootstrap_StaticResources{
 			Listeners: listeners,
 		},

--- a/depot/containerstore/proxy_config_handler_test.go
+++ b/depot/containerstore/proxy_config_handler_test.go
@@ -363,6 +363,9 @@ var _ = Describe("ProxyConfigHandler", func() {
 				Expect(admin.AccessLogPath).To(Equal(os.DevNull))
 				Expect(admin.Address).To(Equal(envoyAddr("127.0.0.1", 61002)))
 
+				Expect(proxyConfig.Node.Id).To(Equal("sidecar~10.0.0.1~container-guid-1~x"))
+				Expect(proxyConfig.Node.Cluster).To(Equal("proxy-cluster"))
+
 				Expect(proxyConfig.StaticResources.Clusters).To(HaveLen(2))
 				expectedCluster{
 					name:           "0-service-cluster",
@@ -532,6 +535,9 @@ var _ = Describe("ProxyConfigHandler", func() {
 			Expect(admin.AccessLogPath).To(Equal(os.DevNull))
 			Expect(admin.Address).To(Equal(envoyAddr("127.0.0.1", 61002)))
 
+			Expect(proxyConfig.Node.Id).To(Equal("sidecar~10.0.0.1~container-guid-1~x"))
+			Expect(proxyConfig.Node.Cluster).To(Equal("proxy-cluster"))
+
 			Expect(proxyConfig.StaticResources.Clusters).To(HaveLen(2))
 			expectedCluster{
 				name:           "0-service-cluster",
@@ -653,6 +659,9 @@ var _ = Describe("ProxyConfigHandler", func() {
 				admin := proxyConfig.Admin
 				Expect(admin.AccessLogPath).To(Equal(os.DevNull))
 				Expect(admin.Address).To(Equal(envoyAddr("127.0.0.1", 61003)))
+
+				Expect(proxyConfig.Node.Id).To(Equal("sidecar~10.0.0.1~container-guid-1~x"))
+				Expect(proxyConfig.Node.Cluster).To(Equal("proxy-cluster"))
 
 				Expect(proxyConfig.StaticResources.Clusters).To(HaveLen(3))
 

--- a/depot/transformer/transformer.go
+++ b/depot/transformer/transformer.go
@@ -722,8 +722,6 @@ func (t *transformer) transformContainerProxyStep(
 	envoyArgs := []string{
 		"-c", "/etc/cf-assets/envoy_config/envoy.yaml",
 		"--v2-config-only",
-		"--service-cluster", "proxy-cluster",
-		"--service-node", fmt.Sprintf("sidecar~%s~x~x", execContainer.InternalIP),
 		"--drain-time-s", strconv.Itoa(int(t.drainWait.Seconds())),
 		"--log-level", "critical",
 	}

--- a/depot/transformer/transformer_test.go
+++ b/depot/transformer/transformer_test.go
@@ -342,7 +342,7 @@ var _ = Describe("Transformer", func() {
 					specs = append(specs, spec)
 				}
 
-				envoyArgs := "-c /etc/cf-assets/envoy_config/envoy.yaml --v2-config-only --service-cluster proxy-cluster --service-node sidecar~11.0.0.1~x~x --drain-time-s 1 --log-level critical"
+				envoyArgs := "-c /etc/cf-assets/envoy_config/envoy.yaml --v2-config-only --drain-time-s 1 --log-level critical"
 
 				path := "sh"
 				args := []string{
@@ -422,7 +422,7 @@ var _ = Describe("Transformer", func() {
 						specs = append(specs, spec)
 					}
 
-					envoyArgs := "-c /etc/cf-assets/envoy_config/envoy.yaml --v2-config-only --service-cluster proxy-cluster --service-node sidecar~11.0.0.1~x~x --drain-time-s 1 --log-level critical"
+					envoyArgs := "-c /etc/cf-assets/envoy_config/envoy.yaml --v2-config-only --drain-time-s 1 --log-level critical"
 
 					path := "sh"
 					args := []string{


### PR DESCRIPTION
Istio Pilot expects the node id to be a `~`-separated list, where the third position is an ID that is unique across the entire cluster.  (This is not clearly documented but can be seen in [this Pilot code](https://github.com/istio/istio/blob/b8e30e07ec7b36cf1ba1b445b78c81fdf0d417b9/pilot/pkg/model/context.go#L230-L270)).

Also: this commit moves the service node id and service cluster name settings off the command-line and into the bootstrap yaml.  This helps consolidate the per-proxy config.  For reference, here is [the Envoy CLI docs](https://www.envoyproxy.io/docs/envoy/latest/operations/cli) vs the [`Node` object in bootstrap config](https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/core/base.proto#envoy-api-msg-core-node).  The latter allows us to extend it to add `metadata` and `locality`, which may be useful for supporting Service Mesh features in the future.