### PR TITLE
Temporarily disable stats logging in envoy to enable scaling goals

### DIFF
--- a/depot/containerstore/proxy_config_handler.go
+++ b/depot/containerstore/proxy_config_handler.go
@@ -24,6 +24,7 @@ import (
 	envoy_v2_listener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	envoy_v2_bootstrap "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v2"
 	envoy_v2_tcp_proxy_filter "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/tcp_proxy/v2"
+	envoy_v2_metrics "github.com/envoyproxy/go-control-plane/envoy/config/metrics/v2"
 	envoy_util "github.com/envoyproxy/go-control-plane/pkg/util"
 	ghodss_yaml "github.com/ghodss/yaml"
 	"github.com/gogo/protobuf/jsonpb"
@@ -324,6 +325,13 @@ func generateProxyConfig(
 		Admin: &envoy_v2_bootstrap.Admin{
 			AccessLogPath: AdminAccessLog,
 			Address:       envoyAddr("127.0.0.1", adminPort),
+		},
+		StatsConfig: &envoy_v2_metrics.StatsConfig{
+			StatsMatcher: &envoy_v2_metrics.StatsMatcher{
+				StatsMatcher: &envoy_v2_metrics.StatsMatcher_RejectAll{
+					RejectAll: true,
+				},
+			},
 		},
 		Node: &envoy_v2_core.Node{
 			Id:      fmt.Sprintf("sidecar~%s~%s~x", container.InternalIP, container.Guid),

--- a/depot/containerstore/proxy_config_handler_test.go
+++ b/depot/containerstore/proxy_config_handler_test.go
@@ -362,6 +362,8 @@ var _ = Describe("ProxyConfigHandler", func() {
 				admin := proxyConfig.Admin
 				Expect(admin.AccessLogPath).To(Equal(os.DevNull))
 				Expect(admin.Address).To(Equal(envoyAddr("127.0.0.1", 61002)))
+				statsMatcher := proxyConfig.StatsConfig
+				Expect(fmt.Sprintf("%+v", statsMatcher.StatsMatcher.StatsMatcher)).To(Equal("&{RejectAll:true}"))
 
 				Expect(proxyConfig.Node.Id).To(Equal(fmt.Sprintf("sidecar~10.0.0.1~%s~x", container.Guid)))
 				Expect(proxyConfig.Node.Cluster).To(Equal("proxy-cluster"))
@@ -511,6 +513,8 @@ var _ = Describe("ProxyConfigHandler", func() {
 			admin := proxyConfig.Admin
 			Expect(admin.AccessLogPath).To(Equal(os.DevNull))
 			Expect(admin.Address).To(Equal(envoyAddr("127.0.0.1", 61002)))
+			statsMatcher := proxyConfig.StatsConfig
+			Expect(fmt.Sprintf("%+v", statsMatcher.StatsMatcher.StatsMatcher)).To(Equal("&{RejectAll:true}"))
 
 			Expect(proxyConfig.Node.Id).To(Equal(fmt.Sprintf("sidecar~10.0.0.1~%s~x", container.Guid)))
 			Expect(proxyConfig.Node.Cluster).To(Equal("proxy-cluster"))
@@ -636,6 +640,8 @@ var _ = Describe("ProxyConfigHandler", func() {
 				admin := proxyConfig.Admin
 				Expect(admin.AccessLogPath).To(Equal(os.DevNull))
 				Expect(admin.Address).To(Equal(envoyAddr("127.0.0.1", 61003)))
+				statsMatcher := proxyConfig.StatsConfig
+				Expect(fmt.Sprintf("%+v", statsMatcher.StatsMatcher.StatsMatcher)).To(Equal("&{RejectAll:true}"))
 
 				Expect(proxyConfig.Node.Id).To(Equal(fmt.Sprintf("sidecar~10.0.0.1~%s~x", container.Guid)))
 				Expect(proxyConfig.Node.Cluster).To(Equal("proxy-cluster"))


### PR DESCRIPTION
We hope to make this configurable in the future, but for now this will
have to do.

[#164185487](https://www.pivotaltracker.com/story/show/164185487)

