### PR TITLE
Add SPIFFE URI in instance cert SAN

### DIFF
--- a/initializer/initializer.go
+++ b/initializer/initializer.go
@@ -123,6 +123,7 @@ type ExecutorConfig struct {
 	InstanceIdentityCredDir            string                `json:"instance_identity_cred_dir,omitempty"`
 	InstanceIdentityPrivateKeyPath     string                `json:"instance_identity_private_key_path,omitempty"`
 	InstanceIdentityValidityPeriod     durationjson.Duration `json:"instance_identity_validity_period,omitempty"`
+	InstanceIdentityAddSpiffeURI       bool                  `json:"instance_identity_add_spiffe_uri,omitempty"`
 	MaxCacheSizeInBytes                uint64                `json:"max_cache_size_in_bytes,omitempty"`
 	MaxConcurrentDownloads             int                   `json:"max_concurrent_downloads,omitempty"`
 	MemoryMB                           string                `json:"memory_mb,omitempty"`
@@ -648,6 +649,7 @@ func CredManagerFromConfig(logger lager.Logger, metronClient loggingclient.Ingre
 			logger,
 			metronClient,
 			time.Duration(config.InstanceIdentityValidityPeriod),
+			config.InstanceIdentityAddSpiffeURI,
 			rand.Reader,
 			clock,
 			certs[0],

--- a/initializer/initializer_test.go
+++ b/initializer/initializer_test.go
@@ -594,6 +594,7 @@ var _ = Describe("Initializer", func() {
 				config.InstanceIdentityCAPath = "fixtures/instance-id/ca.crt"
 				config.InstanceIdentityPrivateKeyPath = "fixtures/instance-id/ca.key"
 				config.InstanceIdentityValidityPeriod = durationjson.Duration(1 * time.Minute)
+				config.InstanceIdentityAddSpiffeURI = true
 			})
 
 			It("returns a credential manager", func() {


### PR DESCRIPTION
This code change introduces an additional SAN URI to Diego's application instance certificate. Doing this will help the networking team achieve mTLS between applications, since the Envoy sidecars are configured to look for this default URI when checking the certificate. 

[Story Link](https://www.pivotaltracker.com/story/show/164511804)

[Spike discovering this need](https://www.pivotaltracker.com/story/show/164183100/comments/200309392)

Regards,
CF Networking