### PR TITLE
Pr spike metric

### DIFF
--- a/containermetrics/cpu_spike_handler.go
+++ b/containermetrics/cpu_spike_handler.go
@@ -1,0 +1,73 @@
+package containermetrics
+
+import (
+	"time"
+
+	loggingclient "code.cloudfoundry.org/diego-logging-client"
+	"code.cloudfoundry.org/executor"
+	"code.cloudfoundry.org/lager"
+)
+
+type spikeInfo struct {
+	start *time.Time
+	end   *time.Time
+}
+
+type CPUSpikeHandler struct {
+	spikeInfos   map[string]*spikeInfo
+	metronClient loggingclient.IngressClient
+}
+
+func NewCPUSpikeHandler(metronClient loggingclient.IngressClient) *CPUSpikeHandler {
+	return &CPUSpikeHandler{
+		spikeInfos:   make(map[string]*spikeInfo),
+		metronClient: metronClient,
+	}
+}
+
+func (handler *CPUSpikeHandler) Handle(logger lager.Logger, container executor.Container, metric executor.Metrics, timeStamp time.Time) error {
+	guid := container.Guid
+	previousSpikeInfo := handler.spikeInfos[guid]
+	currentSpikeInfo := &spikeInfo{}
+
+	if previousSpikeInfo != nil {
+		currentSpikeInfo.start = previousSpikeInfo.start
+		currentSpikeInfo.end = previousSpikeInfo.end
+	}
+
+	if spikeStarted(metric, previousSpikeInfo) {
+		currentSpikeInfo.start = &timeStamp
+		handler.spikeInfos[guid] = currentSpikeInfo
+		return nil
+	}
+
+	if spikeEnded(metric, previousSpikeInfo) {
+		currentSpikeInfo.end = &timeStamp
+
+		err := handler.metronClient.SendSpikeMetrics(loggingclient.SpikeMetric{
+			Start: *currentSpikeInfo.start,
+			End:   *currentSpikeInfo.end,
+			Tags:  metric.MetricsConfig.Tags,
+		})
+		if err != nil {
+			return err
+		}
+
+		handler.spikeInfos[guid] = nil
+		return nil
+	}
+
+	return nil
+}
+
+func spikeStarted(metric executor.Metrics, previousSpikeInfo *spikeInfo) bool {
+	currentlySpiking := uint64(metric.TimeSpentInCPU.Nanoseconds()) > metric.AbsoluteCPUEntitlementInNanoseconds
+	previouslySpiking := previousSpikeInfo != nil && previousSpikeInfo.start != nil
+	return currentlySpiking && !previouslySpiking
+}
+
+func spikeEnded(metric executor.Metrics, previousSpikeInfo *spikeInfo) bool {
+	currentlySpiking := uint64(metric.TimeSpentInCPU.Nanoseconds()) > metric.AbsoluteCPUEntitlementInNanoseconds
+	previouslySpiking := previousSpikeInfo != nil && previousSpikeInfo.start != nil
+	return !currentlySpiking && previouslySpiking
+}

--- a/containermetrics/stats_handler.go
+++ b/containermetrics/stats_handler.go
@@ -1,0 +1,151 @@
+package containermetrics
+
+import (
+	"strconv"
+	"sync/atomic"
+	"time"
+
+	loggingclient "code.cloudfoundry.org/diego-logging-client"
+	"code.cloudfoundry.org/executor"
+	"code.cloudfoundry.org/lager"
+)
+
+type cpuInfo struct {
+	timeSpentInCPU time.Duration
+	timeOfSample   time.Time
+}
+
+type StatsHandler struct {
+	cpuInfos              map[string]*cpuInfo
+	repMetricsMap         map[string]*CachedContainerMetrics
+	metronClient          loggingclient.IngressClient
+	enableContainerProxy  bool
+	proxyMemoryAllocation float64
+	metricsCache          *atomic.Value
+}
+
+func NewStatsHandler(metronClient loggingclient.IngressClient, enableContainerProxy bool, proxyMemoryAllocation float64, metricsCache *atomic.Value) *StatsHandler {
+	return &StatsHandler{
+		cpuInfos:              make(map[string]*cpuInfo),
+		repMetricsMap:         make(map[string]*CachedContainerMetrics),
+		enableContainerProxy:  enableContainerProxy,
+		metronClient:          metronClient,
+		proxyMemoryAllocation: proxyMemoryAllocation,
+		metricsCache:          metricsCache,
+	}
+}
+
+func (handler *StatsHandler) Handle(logger lager.Logger, container executor.Container, metric executor.Metrics, timeStamp time.Time) error {
+	guid := container.Guid
+
+	previousCPUInfo := handler.cpuInfos[guid]
+
+	if handler.enableContainerProxy && container.EnableContainerProxy {
+		metric.MemoryUsageInBytes = uint64(float64(metric.MemoryUsageInBytes) * handler.scaleMemory(container))
+		metric.MemoryLimitInBytes = uint64(float64(metric.MemoryLimitInBytes) - handler.proxyMemoryAllocation)
+	}
+
+	repMetrics, cpu := handler.calculateAndSendMetrics(logger, metric.MetricsConfig, metric.ContainerMetrics, previousCPUInfo, timeStamp)
+	if cpu != nil {
+		handler.cpuInfos[guid] = cpu
+	}
+
+	if repMetrics != nil {
+		handler.repMetricsMap[guid] = repMetrics
+	}
+
+	handler.metricsCache.Store(handler.repMetricsMap)
+	return nil
+}
+
+func (handler *StatsHandler) calculateAndSendMetrics(
+	logger lager.Logger,
+	metricsConfig executor.MetricsConfig,
+	containerMetrics executor.ContainerMetrics,
+	previousInfo *cpuInfo,
+	now time.Time,
+) (*CachedContainerMetrics, *cpuInfo) {
+	currentInfo, cpuPercent := calculateInfo(containerMetrics, previousInfo, now)
+
+	if len(metricsConfig.Tags) == 0 {
+		metricsConfig.Tags = map[string]string{}
+	}
+
+	applicationId := metricsConfig.Guid
+	if sourceID, ok := metricsConfig.Tags["source_id"]; ok {
+		applicationId = sourceID
+	} else {
+		metricsConfig.Tags["source_id"] = applicationId
+	}
+
+	index := strconv.Itoa(metricsConfig.Index)
+	if _, ok := metricsConfig.Tags["instance_id"]; !ok {
+		metricsConfig.Tags["instance_id"] = index
+	}
+
+	if applicationId != "" {
+		err := handler.metronClient.SendAppMetrics(loggingclient.ContainerMetric{
+			CpuPercentage:          cpuPercent,
+			MemoryBytes:            containerMetrics.MemoryUsageInBytes,
+			DiskBytes:              containerMetrics.DiskUsageInBytes,
+			MemoryBytesQuota:       containerMetrics.MemoryLimitInBytes,
+			DiskBytesQuota:         containerMetrics.DiskLimitInBytes,
+			AbsoluteCPUUsage:       uint64(containerMetrics.TimeSpentInCPU.Nanoseconds()),
+			AbsoluteCPUEntitlement: containerMetrics.AbsoluteCPUEntitlementInNanoseconds,
+			ContainerAge:           containerMetrics.ContainerAgeInNanoseconds,
+			Tags:                   metricsConfig.Tags,
+		})
+
+		if err != nil {
+			logger.Error("failed-to-send-container-metrics", err, lager.Data{
+				"metrics_guid":  applicationId,
+				"metrics_index": metricsConfig.Index,
+				"tags":          metricsConfig.Tags,
+			})
+		}
+	}
+
+	return &CachedContainerMetrics{
+		MetricGUID:       applicationId,
+		CPUUsageFraction: cpuPercent / 100,
+		DiskUsageBytes:   containerMetrics.DiskUsageInBytes,
+		DiskQuotaBytes:   containerMetrics.DiskLimitInBytes,
+		MemoryUsageBytes: containerMetrics.MemoryUsageInBytes,
+		MemoryQuotaBytes: containerMetrics.MemoryLimitInBytes,
+	}, &currentInfo
+}
+
+func calculateInfo(containerMetrics executor.ContainerMetrics, previousInfo *cpuInfo, now time.Time) (cpuInfo, float64) {
+	currentInfo := cpuInfo{
+		timeSpentInCPU: containerMetrics.TimeSpentInCPU,
+		timeOfSample:   now,
+	}
+
+	var cpuPercent float64
+	if previousInfo == nil {
+		cpuPercent = 0.0
+	} else {
+		cpuPercent = computeCPUPercent(
+			previousInfo.timeSpentInCPU,
+			currentInfo.timeSpentInCPU,
+			previousInfo.timeOfSample,
+			currentInfo.timeOfSample,
+		)
+	}
+
+	return currentInfo, cpuPercent
+}
+
+// scale from (0 - 100) * runtime.NumCPU()
+func computeCPUPercent(timeSpentA, timeSpentB time.Duration, sampleTimeA, sampleTimeB time.Time) float64 {
+	// divide change in time spent in CPU over time between samples.
+	// result is out of 100 * runtime.NumCPU()
+	//
+	// don't worry about overflowing int64. it's like, 30 years.
+	return float64((timeSpentB-timeSpentA)*100) / float64(sampleTimeB.UnixNano()-sampleTimeA.UnixNano())
+}
+
+func (handler *StatsHandler) scaleMemory(container executor.Container) float64 {
+	memFloat := float64(container.MemoryLimit)
+	return (memFloat - handler.proxyMemoryAllocation) / memFloat
+}

--- a/containermetrics/stats_reporter.go
+++ b/containermetrics/stats_reporter.go
@@ -2,53 +2,43 @@ package containermetrics
 
 import (
 	"os"
-	"strconv"
 	"sync/atomic"
 	"time"
 
 	"code.cloudfoundry.org/clock"
-	loggingclient "code.cloudfoundry.org/diego-logging-client"
 	"code.cloudfoundry.org/executor"
 	"code.cloudfoundry.org/lager"
 )
 
-var megabytesToBytes int = 1024 * 1024
+type MetricsHandler interface {
+	Handle(logger lager.Logger, container executor.Container, metric executor.Metrics, timeStamp time.Time) error
+}
 
 type StatsReporter struct {
 	logger lager.Logger
 
-	interval       time.Duration
-	clock          clock.Clock
-	executorClient executor.Client
-	metrics        atomic.Value
-
-	metronClient          loggingclient.IngressClient
-	enableContainerProxy  bool
-	proxyMemoryAllocation float64
-}
-
-type cpuInfo struct {
-	timeSpentInCPU time.Duration
-	timeOfSample   time.Time
+	interval        time.Duration
+	clock           clock.Clock
+	executorClient  executor.Client
+	metricsCache    *atomic.Value
+	metricsHandlers []MetricsHandler
 }
 
 func NewStatsReporter(logger lager.Logger,
 	interval time.Duration,
 	clock clock.Clock,
-	enableContainerProxy bool,
-	additionalMemoryMB int,
 	executorClient executor.Client,
-	metronClient loggingclient.IngressClient,
+	metricsCache *atomic.Value,
+	metricsHandlers ...MetricsHandler,
 ) *StatsReporter {
 	return &StatsReporter{
 		logger: logger,
 
-		interval:              interval,
-		clock:                 clock,
-		executorClient:        executorClient,
-		metronClient:          metronClient,
-		enableContainerProxy:  enableContainerProxy,
-		proxyMemoryAllocation: float64(additionalMemoryMB * megabytesToBytes),
+		interval:        interval,
+		clock:           clock,
+		executorClient:  executorClient,
+		metricsCache:    metricsCache,
+		metricsHandlers: metricsHandlers,
 	}
 }
 
@@ -60,7 +50,6 @@ func (reporter *StatsReporter) Run(signals <-chan os.Signal, ready chan<- struct
 
 	close(ready)
 
-	cpuInfos := make(map[string]*cpuInfo)
 	for {
 		select {
 		case signal := <-signals:
@@ -68,19 +57,19 @@ func (reporter *StatsReporter) Run(signals <-chan os.Signal, ready chan<- struct
 			return nil
 
 		case now := <-ticker.C():
-			cpuInfos = reporter.emitContainerMetrics(logger, cpuInfos, now)
+			reporter.fetchMetrics(logger, now, reporter.metricsHandlers...)
 		}
 	}
 }
 
 func (reporter *StatsReporter) Metrics() map[string]*CachedContainerMetrics {
-	if v := reporter.metrics.Load(); v != nil {
+	if v := reporter.metricsCache.Load(); v != nil {
 		return v.(map[string]*CachedContainerMetrics)
 	}
 	return nil
 }
 
-func (reporter *StatsReporter) emitContainerMetrics(logger lager.Logger, previousCPUInfos map[string]*cpuInfo, now time.Time) map[string]*cpuInfo {
+func (reporter *StatsReporter) fetchMetrics(logger lager.Logger, timeStamp time.Time, handlers ...MetricsHandler) {
 	logger = logger.Session("tick")
 
 	startTime := reporter.clock.Now()
@@ -92,138 +81,30 @@ func (reporter *StatsReporter) emitContainerMetrics(logger lager.Logger, previou
 		})
 	}()
 
-	metrics, err := reporter.executorClient.GetBulkMetrics(logger)
+	metricsCache, err := reporter.executorClient.GetBulkMetrics(logger)
 	if err != nil {
 		logger.Error("failed-to-get-all-metrics", err)
-		return previousCPUInfos
+		return
 	}
 
 	logger.Debug("emitting", lager.Data{
-		"total-containers": len(metrics),
+		"total-containers": len(metricsCache),
 		"get-metrics-took": reporter.clock.Now().Sub(startTime).String(),
 	})
 
 	containers, err := reporter.executorClient.ListContainers(logger)
 	if err != nil {
 		logger.Error("failed-to-fetch-containers", err)
-		return previousCPUInfos
+		return
 	}
-
-	newCPUInfos := make(map[string]*cpuInfo)
-	repMetricsMap := make(map[string]*CachedContainerMetrics)
 
 	for _, container := range containers {
-		guid := container.Guid
-		metric := metrics[guid]
-
-		previousCPUInfo := previousCPUInfos[guid]
-
-		if reporter.enableContainerProxy && container.EnableContainerProxy {
-			metric.MemoryUsageInBytes = uint64(float64(metric.MemoryUsageInBytes) * reporter.scaleMemory(container))
-			metric.MemoryLimitInBytes = uint64(float64(metric.MemoryLimitInBytes) - reporter.proxyMemoryAllocation)
-		}
-
-		repMetrics, cpu := reporter.calculateAndSendMetrics(logger, metric.MetricsConfig, metric.ContainerMetrics, previousCPUInfo, now)
-		if cpu != nil {
-			newCPUInfos[guid] = cpu
-		}
-
-		if repMetrics != nil {
-			repMetricsMap[guid] = repMetrics
+		metric := metricsCache[container.Guid]
+		for _, handler := range handlers {
+			err := handler.Handle(logger, container, metric, timeStamp)
+			if err != nil {
+				logger.Error("failed-to-handle-metric", err, lager.Data{"container": container, "metric": metric})
+			}
 		}
 	}
-
-	reporter.metrics.Store(repMetricsMap)
-	return newCPUInfos
-}
-
-func (reporter *StatsReporter) calculateAndSendMetrics(
-	logger lager.Logger,
-	metricsConfig executor.MetricsConfig,
-	containerMetrics executor.ContainerMetrics,
-	previousInfo *cpuInfo,
-	now time.Time,
-) (*CachedContainerMetrics, *cpuInfo) {
-	currentInfo, cpuPercent := calculateInfo(containerMetrics, previousInfo, now)
-
-	if len(metricsConfig.Tags) == 0 {
-		metricsConfig.Tags = map[string]string{}
-	}
-
-	applicationId := metricsConfig.Guid
-	if sourceID, ok := metricsConfig.Tags["source_id"]; ok {
-		applicationId = sourceID
-	} else {
-		metricsConfig.Tags["source_id"] = applicationId
-	}
-
-	index := strconv.Itoa(metricsConfig.Index)
-	if _, ok := metricsConfig.Tags["instance_id"]; !ok {
-		metricsConfig.Tags["instance_id"] = index
-	}
-
-	if applicationId != "" {
-		err := reporter.metronClient.SendAppMetrics(loggingclient.ContainerMetric{
-			CpuPercentage:          cpuPercent,
-			MemoryBytes:            containerMetrics.MemoryUsageInBytes,
-			DiskBytes:              containerMetrics.DiskUsageInBytes,
-			MemoryBytesQuota:       containerMetrics.MemoryLimitInBytes,
-			DiskBytesQuota:         containerMetrics.DiskLimitInBytes,
-			AbsoluteCPUUsage:       uint64(containerMetrics.TimeSpentInCPU.Nanoseconds()),
-			AbsoluteCPUEntitlement: containerMetrics.AbsoluteCPUEntitlementInNanoseconds,
-			ContainerAge:           containerMetrics.ContainerAgeInNanoseconds,
-			Tags:                   metricsConfig.Tags,
-		})
-
-		if err != nil {
-			logger.Error("failed-to-send-container-metrics", err, lager.Data{
-				"metrics_guid":  applicationId,
-				"metrics_index": metricsConfig.Index,
-				"tags":          metricsConfig.Tags,
-			})
-		}
-	}
-
-	return &CachedContainerMetrics{
-		MetricGUID:       applicationId,
-		CPUUsageFraction: cpuPercent / 100,
-		DiskUsageBytes:   containerMetrics.DiskUsageInBytes,
-		DiskQuotaBytes:   containerMetrics.DiskLimitInBytes,
-		MemoryUsageBytes: containerMetrics.MemoryUsageInBytes,
-		MemoryQuotaBytes: containerMetrics.MemoryLimitInBytes,
-	}, &currentInfo
-}
-
-func calculateInfo(containerMetrics executor.ContainerMetrics, previousInfo *cpuInfo, now time.Time) (cpuInfo, float64) {
-	currentInfo := cpuInfo{
-		timeSpentInCPU: containerMetrics.TimeSpentInCPU,
-		timeOfSample:   now,
-	}
-
-	var cpuPercent float64
-	if previousInfo == nil {
-		cpuPercent = 0.0
-	} else {
-		cpuPercent = computeCPUPercent(
-			previousInfo.timeSpentInCPU,
-			currentInfo.timeSpentInCPU,
-			previousInfo.timeOfSample,
-			currentInfo.timeOfSample,
-		)
-	}
-	return currentInfo, cpuPercent
-}
-
-// scale from (0 - 100) * runtime.NumCPU()
-func computeCPUPercent(timeSpentA, timeSpentB time.Duration, sampleTimeA, sampleTimeB time.Time) float64 {
-	// divide change in time spent in CPU over time between samples.
-	// result is out of 100 * runtime.NumCPU()
-	//
-	// don't worry about overflowing int64. it's like, 30 years.
-	return float64((timeSpentB-timeSpentA)*100) / float64(sampleTimeB.UnixNano()-sampleTimeA.UnixNano())
-}
-
-func (reporter *StatsReporter) scaleMemory(container executor.Container) float64 {
-	memFloat := float64(container.MemoryLimit)
-	return (memFloat - reporter.proxyMemoryAllocation) / memFloat
 }

--- a/initializer/initializer.go
+++ b/initializer/initializer.go
@@ -358,6 +358,7 @@ func Initialize(logger lager.Logger, config ExecutorConfig, cellID, zone string,
 		float64(config.ProxyMemoryAllocationMB*megabytesToBytes),
 		metricsCache,
 	)
+	cpuSpikeHandler := containermetrics.NewCPUSpikeHandler(metronClient)
 
 	statsReporter := containermetrics.NewStatsReporter(
 		logger,
@@ -366,6 +367,7 @@ func Initialize(logger lager.Logger, config ExecutorConfig, cellID, zone string,
 		depotClient,
 		metricsCache,
 		containerMetricsHandler,
+		cpuSpikeHandler,
 	)
 
 	return depotClient, statsReporter,


### PR DESCRIPTION
Hi Diego Team,

We at Garden are working on a cf-cli plugin that displays cpu stats to cf users, such as current and average CPU usage and whether or not some instances have spiked historically (over last month for example). Current CPU entitlement metrics that Diego is emitting (like container age, cpu entitlement, cpu usage) are not sufficient to calculate if and when cpu usage spikes occurred in a reliable and performant way. 

We already tried a client-side approach where the cli plugin would calculate spikes based on metrics we are currently emitting, but this leads to processing very large amounts of data (we have data for each instance every 15s during last month) which is inadequately slow.

This draft PR suggests that Diego starts emitting a new metric that designates CPU spikes. This new metric will be emitted only when a running cpu spike ends (rather than regularly each 15s) which will lead to very few data points for the cpu plugin to process. This way the cpu plugin performance is comparable with the  `cf apps` command which is adequate.

We think that emitting such a metric will also be of great value for future development of ops tools that report apps that have exceeded their cpu entitlement and should be throttled.

What do you think about introducing this new metric?

PS: This PR is not standalone. It is complemented by [this draft PR](https://github.com/cloudfoundry/diego-logging-client/pull/7) in the `diego-logging-client`