### PR TITLE
Let's Emit a CPU Usage Spike Metric

### DIFF
--- a/containermetrics/cpu_spike_reporter.go
+++ b/containermetrics/cpu_spike_reporter.go
@@ -1,0 +1,83 @@
+package containermetrics
+
+import (
+	"time"
+
+	loggingclient "code.cloudfoundry.org/diego-logging-client"
+	"code.cloudfoundry.org/executor"
+	"code.cloudfoundry.org/lager"
+)
+
+type spikeInfo struct {
+	start *time.Time
+	end   *time.Time
+}
+
+type CPUSpikeReporter struct {
+	spikeInfos   map[string]*spikeInfo
+	metronClient loggingclient.IngressClient
+}
+
+func NewCPUSpikeReporter(metronClient loggingclient.IngressClient) *CPUSpikeReporter {
+	return &CPUSpikeReporter{
+		spikeInfos:   make(map[string]*spikeInfo),
+		metronClient: metronClient,
+	}
+}
+
+func (reporter *CPUSpikeReporter) Report(logger lager.Logger, containers []executor.Container, metrics map[string]executor.Metrics, timeStamp time.Time) error {
+	spikeInfos := map[string]*spikeInfo{}
+
+	for _, container := range containers {
+		guid := container.Guid
+		metric, ok := metrics[guid]
+		if !ok {
+			continue
+		}
+		spikeInfos[guid] = reporter.spikeInfos[guid]
+
+		previousSpikeInfo := spikeInfos[guid]
+		currentSpikeInfo := &spikeInfo{}
+
+		if previousSpikeInfo != nil {
+			currentSpikeInfo.start = previousSpikeInfo.start
+			currentSpikeInfo.end = previousSpikeInfo.end
+		}
+
+		if spikeStarted(metric, previousSpikeInfo) {
+			currentSpikeInfo.start = &timeStamp
+			spikeInfos[guid] = currentSpikeInfo
+			continue
+		}
+
+		if spikeEnded(metric, previousSpikeInfo) {
+			currentSpikeInfo.end = &timeStamp
+
+			err := reporter.metronClient.SendSpikeMetrics(loggingclient.SpikeMetric{
+				Start: *currentSpikeInfo.start,
+				End:   *currentSpikeInfo.end,
+				Tags:  metric.MetricsConfig.Tags,
+			})
+			if err != nil {
+				return err
+			}
+
+			delete(spikeInfos, guid)
+		}
+	}
+
+	reporter.spikeInfos = spikeInfos
+	return nil
+}
+
+func spikeStarted(metric executor.Metrics, previousSpikeInfo *spikeInfo) bool {
+	currentlySpiking := uint64(metric.TimeSpentInCPU.Nanoseconds()) > metric.AbsoluteCPUEntitlementInNanoseconds
+	previouslySpiking := previousSpikeInfo != nil && previousSpikeInfo.start != nil
+	return currentlySpiking && !previouslySpiking
+}
+
+func spikeEnded(metric executor.Metrics, previousSpikeInfo *spikeInfo) bool {
+	currentlySpiking := uint64(metric.TimeSpentInCPU.Nanoseconds()) > metric.AbsoluteCPUEntitlementInNanoseconds
+	previouslySpiking := previousSpikeInfo != nil && previousSpikeInfo.start != nil
+	return !currentlySpiking && previouslySpiking
+}

--- a/containermetrics/reporters_runner.go
+++ b/containermetrics/reporters_runner.go
@@ -1,0 +1,96 @@
+package containermetrics
+
+import (
+	"os"
+	"time"
+
+	"code.cloudfoundry.org/clock"
+	"code.cloudfoundry.org/executor"
+	"code.cloudfoundry.org/lager"
+)
+
+type ReportersRunner struct {
+	logger lager.Logger
+
+	interval         time.Duration
+	clock            clock.Clock
+	executorClient   executor.Client
+	metricsReporters []MetricsReporter
+}
+
+type MetricsReporter interface {
+	Report(logger lager.Logger, containers []executor.Container, metrics map[string]executor.Metrics, timeStamp time.Time) error
+}
+
+func NewReportersRunner(logger lager.Logger,
+	interval time.Duration,
+	clock clock.Clock,
+	executorClient executor.Client,
+	metricsReporters ...MetricsReporter,
+) *ReportersRunner {
+	return &ReportersRunner{
+		logger: logger,
+
+		interval:         interval,
+		clock:            clock,
+		executorClient:   executorClient,
+		metricsReporters: metricsReporters,
+	}
+}
+
+func (reporterRunner *ReportersRunner) Run(signals <-chan os.Signal, ready chan<- struct{}) error {
+	logger := reporterRunner.logger.Session("container-metrics-reporterRunner")
+
+	ticker := reporterRunner.clock.NewTicker(reporterRunner.interval)
+	defer ticker.Stop()
+
+	close(ready)
+
+	for {
+		select {
+		case signal := <-signals:
+			logger.Info("signalled", lager.Data{"signal": signal.String()})
+			return nil
+
+		case now := <-ticker.C():
+			reporterRunner.fetchMetrics(logger, now, reporterRunner.metricsReporters...)
+		}
+	}
+}
+
+func (reporterRunner *ReportersRunner) fetchMetrics(logger lager.Logger, timeStamp time.Time, reporters ...MetricsReporter) {
+	logger = logger.Session("tick")
+
+	startTime := reporterRunner.clock.Now()
+
+	logger.Debug("started")
+	defer func() {
+		logger.Debug("done", lager.Data{
+			"took": reporterRunner.clock.Now().Sub(startTime).String(),
+		})
+	}()
+
+	metricsCache, err := reporterRunner.executorClient.GetBulkMetrics(logger)
+	if err != nil {
+		logger.Error("failed-to-get-all-metrics", err)
+		return
+	}
+
+	logger.Debug("emitting", lager.Data{
+		"total-containers": len(metricsCache),
+		"get-metrics-took": reporterRunner.clock.Now().Sub(startTime).String(),
+	})
+
+	containers, err := reporterRunner.executorClient.ListContainers(logger)
+	if err != nil {
+		logger.Error("failed-to-fetch-containers", err)
+		return
+	}
+
+	for _, reporter := range reporters {
+		err := reporter.Report(logger, containers, metricsCache, timeStamp)
+		if err != nil {
+			logger.Error("failed-to-report-metric", err, lager.Data{"containers": containers, "metrics": metricsCache, "reporter": reporter})
+		}
+	}
+}


### PR DESCRIPTION
Hi Diego Team,

We at Garden are working on a cf-cli plugin that displays cpu stats to cf users, such as current and average CPU usage and whether or not some instances have spiked historically (over last month for example). Current CPU entitlement metrics that Diego is emitting (like container age, cpu entitlement, cpu usage) are not sufficient to calculate if and when cpu usage spikes occurred in a reliable and performant way. 

We already tried a client-side approach where the cli plugin would calculate spikes based on metrics we are currently emitting, but this leads to processing very large amounts of data (we have data for each instance every 15s during last month) which is inadequately slow.

This draft PR suggests that Diego starts emitting a new metric that designates CPU spikes. This new metric will be emitted only when a running cpu spike ends (rather than regularly each 15s) which will lead to very few data points for the cpu plugin to process. This way the cpu plugin performance is comparable with the  `cf apps` command which is adequate.

We think that emitting such a metric will also be of great value for future development of ops tools that report apps that have exceeded their cpu entitlement and should be throttled.

What do you think about introducing this new metric?

PS: This PR is not standalone. It is complemented by [this draft PR](https://github.com/cloudfoundry/diego-logging-client/pull/7) in the `diego-logging-client`