### PR TITLE
Send cpu spike metric on every reporter interation

### DIFF
--- a/containermetrics/cpu_spike_reporter.go
+++ b/containermetrics/cpu_spike_reporter.go
@@ -9,8 +9,8 @@ import (
 )
 
 type spikeInfo struct {
-	start *time.Time
-	end   *time.Time
+	start time.Time
+	end   time.Time
 }
 
 type CPUSpikeReporter struct {
@@ -26,17 +26,14 @@ func NewCPUSpikeReporter(metronClient loggingclient.IngressClient) *CPUSpikeRepo
 }
 
 func (reporter *CPUSpikeReporter) Report(logger lager.Logger, containers []executor.Container, metrics map[string]executor.Metrics, timeStamp time.Time) error {
-	spikeInfos := map[string]*spikeInfo{}
-
 	for _, container := range containers {
 		guid := container.Guid
 		metric, ok := metrics[guid]
 		if !ok {
 			continue
 		}
-		spikeInfos[guid] = reporter.spikeInfos[guid]
 
-		previousSpikeInfo := spikeInfos[guid]
+		previousSpikeInfo := reporter.spikeInfos[guid]
 		currentSpikeInfo := &spikeInfo{}
 
 		if previousSpikeInfo != nil {
@@ -45,39 +42,39 @@ func (reporter *CPUSpikeReporter) Report(logger lager.Logger, containers []execu
 		}
 
 		if spikeStarted(metric, previousSpikeInfo) {
-			currentSpikeInfo.start = &timeStamp
-			spikeInfos[guid] = currentSpikeInfo
-			continue
+			currentSpikeInfo.start = timeStamp
+			currentSpikeInfo.end = time.Time{}
 		}
 
 		if spikeEnded(metric, previousSpikeInfo) {
-			currentSpikeInfo.end = &timeStamp
+			currentSpikeInfo.end = timeStamp
+		}
 
+		reporter.spikeInfos[guid] = currentSpikeInfo
+
+		if !currentSpikeInfo.start.IsZero() {
 			err := reporter.metronClient.SendSpikeMetrics(loggingclient.SpikeMetric{
-				Start: *currentSpikeInfo.start,
-				End:   *currentSpikeInfo.end,
+				Start: currentSpikeInfo.start,
+				End:   currentSpikeInfo.end,
 				Tags:  metric.MetricsConfig.Tags,
 			})
 			if err != nil {
 				return err
 			}
-
-			delete(spikeInfos, guid)
 		}
 	}
 
-	reporter.spikeInfos = spikeInfos
 	return nil
 }
 
 func spikeStarted(metric executor.Metrics, previousSpikeInfo *spikeInfo) bool {
 	currentlySpiking := uint64(metric.TimeSpentInCPU.Nanoseconds()) > metric.AbsoluteCPUEntitlementInNanoseconds
-	previouslySpiking := previousSpikeInfo != nil && previousSpikeInfo.start != nil
+	previouslySpiking := previousSpikeInfo != nil && !previousSpikeInfo.start.IsZero() && previousSpikeInfo.end.IsZero()
 	return currentlySpiking && !previouslySpiking
 }
 
 func spikeEnded(metric executor.Metrics, previousSpikeInfo *spikeInfo) bool {
 	currentlySpiking := uint64(metric.TimeSpentInCPU.Nanoseconds()) > metric.AbsoluteCPUEntitlementInNanoseconds
-	previouslySpiking := previousSpikeInfo != nil && previousSpikeInfo.start != nil
+	previouslySpiking := previousSpikeInfo != nil && !previousSpikeInfo.start.IsZero() && previousSpikeInfo.end.IsZero()
 	return !currentlySpiking && previouslySpiking
 }


### PR DESCRIPTION
Due to the log cache feature of pruning old entries when full it is very
possible that spike metrics are lost if emitted on spike end only. This
change makes the spike reporter consistently send the last spike metric
on every iteration

[#169621278]

Co-authored-by: Mario Nitchev <marionitchev@gmail.com>