### PR TITLE
Advertise HTTP/2 protocol in Envoy via ALPN

### DIFF
--- a/depot/containerstore/proxy_config_handler.go
+++ b/depot/containerstore/proxy_config_handler.go
@@ -54,6 +54,7 @@ var (
 	ErrNoPortsAvailable   = errors.New("no ports available")
 	ErrInvalidCertificate = errors.New("cannot parse invalid certificate")
 
+	AlpnProtocols         = []string{"h2,http/1.1"}
 	SupportedCipherSuites = []string{"ECDHE-RSA-AES256-GCM-SHA384", "ECDHE-RSA-AES128-GCM-SHA256"}
 )
 
@@ -462,6 +463,7 @@ func generateListeners(container executor.Container, requireClientCerts bool) ([
 		tlsContext := &envoy_tls.DownstreamTlsContext{
 			RequireClientCertificate: &wrappers.BoolValue{Value: requireClientCerts},
 			CommonTlsContext: &envoy_tls.CommonTlsContext{
+				AlpnProtocols: AlpnProtocols,
 				TlsCertificateSdsSecretConfigs: []*envoy_tls.SdsSecretConfig{
 					{
 						Name: "server-cert-and-key",

--- a/depot/containerstore/proxy_config_handler_test.go
+++ b/depot/containerstore/proxy_config_handler_test.go
@@ -869,6 +869,7 @@ func (l expectedListener) check(listener *envoy_listener.Listener) {
 	Expect(filterChain.TransportSocket.Name).To(Equal(l.name))
 
 	Expect(downstreamTlsContext.RequireClientCertificate.Value).To(Equal(l.requireClientCertificate))
+	Expect(downstreamTlsContext.CommonTlsContext.AlpnProtocols).To(Equal([]string{"h2,http/1.1"}))
 	Expect(downstreamTlsContext.CommonTlsContext.TlsCertificateSdsSecretConfigs).To(ConsistOf(
 		&envoy_tls.SdsSecretConfig{
 			Name: "server-cert-and-key",


### PR DESCRIPTION
Add the list of ALPN protocols that will be used by Envoy for
negotiation when connecting to applications.

[#178805678](https://www.pivotaltracker.com/story/show/178805678)

Co-authored-by: Merric de Launey <mdelauney@vmware.com>

### What is this change about?

Executor now generates Envoy config with `AlpnProtocols` list as `h2,http/1.1`

### What problem it is trying to solve?

It allows Gorouter to communicate with Envoy over HTTP2

### What is the impact if the change is not made?

There would be no end to end HTTP2 support.

### How should this change be described in diego-release release notes?

Update Envoy configuration to include http2 and http/1.1 ALPN Protocols

### Please provide any contextual information.

Routing release issue - https://github.com/cloudfoundry/routing-release/issues/200

### Tag your pair, your PM, and/or team!

@weymanf

Thank you!
