### PR TITLE
Make Envoy ALPN configurable

### DIFF
--- a/initializer/initializer.go
+++ b/initializer/initializer.go
@@ -139,6 +139,7 @@ type ExecutorConfig struct {
 	PathToTLSKey                          string                `json:"path_to_tls_key"`
 	PostSetupHook                         string                `json:"post_setup_hook"`
 	PostSetupUser                         string                `json:"post_setup_user"`
+	ProxyEnableHttp2                      bool                  `json:"proxy_enable_http2"`
 	ProxyMemoryAllocationMB               int                   `json:"proxy_memory_allocation_mb,omitempty"`
 	ReadWorkPoolSize                      int                   `json:"read_work_pool_size,omitempty"`
 	ReservedExpirationTime                durationjson.Duration `json:"reserved_expiration_time,omitempty"`
@@ -290,6 +291,7 @@ func Initialize(logger lager.Logger, config ExecutorConfig, cellID, zone string,
 			time.Duration(config.EnvoyConfigReloadDuration),
 			clock,
 			config.ContainerProxyADSServers,
+			config.ProxyEnableHttp2,
 		)
 	} else {
 		proxyConfigHandler = containerstore.NewNoopProxyConfigHandler()


### PR DESCRIPTION
- Allows disabling ALPN configuration for environments where envoy
should not advertise h2 support

---

Thank you for submitting a pull request to the executor repository!

We appreciate the contribution. To help us understand the context for your pull request, please fill out this template to the best of your ability.

## Please make sure to complete all of the following steps

1. Check the [Contributing document](https://github.com/cloudfoundry/diego-release/blob/develop/CONTRIBUTING.md) on how to sign the CLA and run tests.
1. Submit your PR to this repo.
1. [**Submit an accompanying PR Review Request**](https://github.com/cloudfoundry/diego-release/issues/new?assignees=&labels=&template=pr-review-request.md&title=%5BEXECUTOR+PR+REVIEW%5D%3A) referencing this PR so the Diego Team knows to review your pull request. 
* **Note: this PR will not be reviewed unless you submit the [PR Review Request](https://github.com/cloudfoundry/diego-release/issues/new?assignees=&labels=&template=pr-review-request.md&title=%5BEXECUTOR+PR+REVIEW%5D%3A)**.

***************************

## Please provide the following information:

### What is this change about?

Implement change described in cloudfoundry/diego-release#592

### What problem it is trying to solve?

Envoy offering HTTP/2 via ALPN in environment where that causes problems.

### What is the impact if the change is not made?

Clients other than Gorouter connecting to the Envoy proxy may incorrectly start talking HTTP/2 to LRPs that cannot serve HTTP/2.

### How should this change be described in diego-release release notes?

Add manifest property to configure HTTP/2 for container proxies.

### Please provide any contextual information.

Diego release issue: cloudfoundry/diego-release#592
Root issue: cloudfoundry/routing-release#200
