### PR TITLE
Envoy 1.19 should use original TCP connection pool

### DIFF
--- a/depot/containerstore/proxy_config_handler.go
+++ b/depot/containerstore/proxy_config_handler.go
@@ -33,6 +33,7 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/golang/protobuf/ptypes/duration"
+	pstruct "github.com/golang/protobuf/ptypes/struct"
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/tedsuo/ifrit"
 )
@@ -361,6 +362,40 @@ func generateProxyConfig(
 		},
 		StaticResources: &envoy_bootstrap.Bootstrap_StaticResources{
 			Listeners: listeners,
+		},
+		LayeredRuntime: &envoy_bootstrap.LayeredRuntime{
+			Layers: []*envoy_bootstrap.RuntimeLayer{
+				{
+					Name: "static-layer",
+					LayerSpecifier: &envoy_bootstrap.RuntimeLayer_StaticLayer{
+						StaticLayer: &pstruct.Struct{
+							Fields: map[string]*pstruct.Value{
+								"envoy": &pstruct.Value{
+									Kind: &pstruct.Value_StructValue{
+										StructValue: &pstruct.Struct{
+											Fields: map[string]*pstruct.Value{
+												"reloadable_features": &pstruct.Value{
+													Kind: &pstruct.Value_StructValue{
+														StructValue: &pstruct.Struct{
+															Fields: map[string]*pstruct.Value{
+																"new_tcp_connection_pool": &pstruct.Value{
+																	Kind: &pstruct.Value_BoolValue{
+																		BoolValue: false,
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 

--- a/depot/containerstore/proxy_config_handler_test.go
+++ b/depot/containerstore/proxy_config_handler_test.go
@@ -529,6 +529,11 @@ var _ = Describe("ProxyConfigHandler", func() {
 			Expect(proxyConfig.Node.Id).To(Equal(fmt.Sprintf("sidecar~10.0.0.1~%s~x", container.Guid)))
 			Expect(proxyConfig.Node.Cluster).To(Equal("proxy-cluster"))
 
+			Expect(proxyConfig.LayeredRuntime).NotTo(BeNil())
+			Expect(proxyConfig.LayeredRuntime.Layers).To(HaveLen(1))
+			Expect(proxyConfig.LayeredRuntime.Layers[0].LayerSpecifier).To(BeAssignableToTypeOf(&envoy_bootstrap.RuntimeLayer_StaticLayer{}))
+			Expect(proxyConfig.LayeredRuntime.Layers[0].GetStaticLayer().String()).To(Equal(`fields:<key:"envoy" value:<struct_value:<fields:<key:"reloadable_features" value:<struct_value:<fields:<key:"new_tcp_connection_pool" value:<bool_value:false > > > > > > > > `))
+
 			Expect(proxyConfig.StaticResources.Clusters).To(HaveLen(2))
 			expectedCluster{
 				name:           "0-service-cluster",


### PR DESCRIPTION
As of envoy 1.19 (https://www.envoyproxy.io/docs/envoy/v1.20.0/version_history/v1.19.0) the default TCP connection pool has been switched. The new connection pool is not respecting [max_connections value set for Circuit breakers](https://www.envoyproxy.io/docs/envoy/v1.20.0/api-v3/config/cluster/v3/circuit_breaker.proto.html?highlight=max_connections#config-cluster-v3-circuitbreakers-thresholds). This is causing an issue where only 1024 connections is created.

Upstream Issue: envoyproxy/envoy#19033
Fixes: cloudfoundry/diego-release#603
Tracker: [#180186552]

