### PR TITLE
Add TLS listener with app internal routes in SAN to Envoy

### DIFF
--- a/depot/containerstore/containerstorefakes/fake_cred_handler.go
+++ b/depot/containerstore/containerstorefakes/fake_cred_handler.go
@@ -11,10 +11,10 @@ import (
 )
 
 type FakeCredentialHandler struct {
-	CloseStub        func(containerstore.Credential, executor.Container) error
+	CloseStub        func(containerstore.Credentials, executor.Container) error
 	closeMutex       sync.RWMutex
 	closeArgsForCall []struct {
-		arg1 containerstore.Credential
+		arg1 containerstore.Credentials
 		arg2 executor.Container
 	}
 	closeReturns struct {
@@ -51,10 +51,10 @@ type FakeCredentialHandler struct {
 	removeDirReturnsOnCall map[int]struct {
 		result1 error
 	}
-	UpdateStub        func(containerstore.Credential, executor.Container) error
+	UpdateStub        func(containerstore.Credentials, executor.Container) error
 	updateMutex       sync.RWMutex
 	updateArgsForCall []struct {
-		arg1 containerstore.Credential
+		arg1 containerstore.Credentials
 		arg2 executor.Container
 	}
 	updateReturns struct {
@@ -67,11 +67,11 @@ type FakeCredentialHandler struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeCredentialHandler) Close(arg1 containerstore.Credential, arg2 executor.Container) error {
+func (fake *FakeCredentialHandler) Close(arg1 containerstore.Credentials, arg2 executor.Container) error {
 	fake.closeMutex.Lock()
 	ret, specificReturn := fake.closeReturnsOnCall[len(fake.closeArgsForCall)]
 	fake.closeArgsForCall = append(fake.closeArgsForCall, struct {
-		arg1 containerstore.Credential
+		arg1 containerstore.Credentials
 		arg2 executor.Container
 	}{arg1, arg2})
 	stub := fake.CloseStub
@@ -93,13 +93,13 @@ func (fake *FakeCredentialHandler) CloseCallCount() int {
 	return len(fake.closeArgsForCall)
 }
 
-func (fake *FakeCredentialHandler) CloseCalls(stub func(containerstore.Credential, executor.Container) error) {
+func (fake *FakeCredentialHandler) CloseCalls(stub func(containerstore.Credentials, executor.Container) error) {
 	fake.closeMutex.Lock()
 	defer fake.closeMutex.Unlock()
 	fake.CloseStub = stub
 }
 
-func (fake *FakeCredentialHandler) CloseArgsForCall(i int) (containerstore.Credential, executor.Container) {
+func (fake *FakeCredentialHandler) CloseArgsForCall(i int) (containerstore.Credentials, executor.Container) {
 	fake.closeMutex.RLock()
 	defer fake.closeMutex.RUnlock()
 	argsForCall := fake.closeArgsForCall[i]
@@ -259,11 +259,11 @@ func (fake *FakeCredentialHandler) RemoveDirReturnsOnCall(i int, result1 error) 
 	}{result1}
 }
 
-func (fake *FakeCredentialHandler) Update(arg1 containerstore.Credential, arg2 executor.Container) error {
+func (fake *FakeCredentialHandler) Update(arg1 containerstore.Credentials, arg2 executor.Container) error {
 	fake.updateMutex.Lock()
 	ret, specificReturn := fake.updateReturnsOnCall[len(fake.updateArgsForCall)]
 	fake.updateArgsForCall = append(fake.updateArgsForCall, struct {
-		arg1 containerstore.Credential
+		arg1 containerstore.Credentials
 		arg2 executor.Container
 	}{arg1, arg2})
 	stub := fake.UpdateStub
@@ -285,13 +285,13 @@ func (fake *FakeCredentialHandler) UpdateCallCount() int {
 	return len(fake.updateArgsForCall)
 }
 
-func (fake *FakeCredentialHandler) UpdateCalls(stub func(containerstore.Credential, executor.Container) error) {
+func (fake *FakeCredentialHandler) UpdateCalls(stub func(containerstore.Credentials, executor.Container) error) {
 	fake.updateMutex.Lock()
 	defer fake.updateMutex.Unlock()
 	fake.UpdateStub = stub
 }
 
-func (fake *FakeCredentialHandler) UpdateArgsForCall(i int) (containerstore.Credential, executor.Container) {
+func (fake *FakeCredentialHandler) UpdateArgsForCall(i int) (containerstore.Credentials, executor.Container) {
 	fake.updateMutex.RLock()
 	defer fake.updateMutex.RUnlock()
 	argsForCall := fake.updateArgsForCall[i]

--- a/depot/containerstore/containerstorefakes/fake_proxymanager.go
+++ b/depot/containerstore/containerstorefakes/fake_proxymanager.go
@@ -11,10 +11,10 @@ import (
 )
 
 type FakeProxyManager struct {
-	CloseStub        func(containerstore.Credential, executor.Container) error
+	CloseStub        func(containerstore.Credentials, executor.Container) error
 	closeMutex       sync.RWMutex
 	closeArgsForCall []struct {
-		arg1 containerstore.Credential
+		arg1 containerstore.Credentials
 		arg2 executor.Container
 	}
 	closeReturns struct {
@@ -67,10 +67,10 @@ type FakeProxyManager struct {
 	removeDirReturnsOnCall map[int]struct {
 		result1 error
 	}
-	UpdateStub        func(containerstore.Credential, executor.Container) error
+	UpdateStub        func(containerstore.Credentials, executor.Container) error
 	updateMutex       sync.RWMutex
 	updateArgsForCall []struct {
-		arg1 containerstore.Credential
+		arg1 containerstore.Credentials
 		arg2 executor.Container
 	}
 	updateReturns struct {
@@ -83,11 +83,11 @@ type FakeProxyManager struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeProxyManager) Close(arg1 containerstore.Credential, arg2 executor.Container) error {
+func (fake *FakeProxyManager) Close(arg1 containerstore.Credentials, arg2 executor.Container) error {
 	fake.closeMutex.Lock()
 	ret, specificReturn := fake.closeReturnsOnCall[len(fake.closeArgsForCall)]
 	fake.closeArgsForCall = append(fake.closeArgsForCall, struct {
-		arg1 containerstore.Credential
+		arg1 containerstore.Credentials
 		arg2 executor.Container
 	}{arg1, arg2})
 	stub := fake.CloseStub
@@ -109,13 +109,13 @@ func (fake *FakeProxyManager) CloseCallCount() int {
 	return len(fake.closeArgsForCall)
 }
 
-func (fake *FakeProxyManager) CloseCalls(stub func(containerstore.Credential, executor.Container) error) {
+func (fake *FakeProxyManager) CloseCalls(stub func(containerstore.Credentials, executor.Container) error) {
 	fake.closeMutex.Lock()
 	defer fake.closeMutex.Unlock()
 	fake.CloseStub = stub
 }
 
-func (fake *FakeProxyManager) CloseArgsForCall(i int) (containerstore.Credential, executor.Container) {
+func (fake *FakeProxyManager) CloseArgsForCall(i int) (containerstore.Credentials, executor.Container) {
 	fake.closeMutex.RLock()
 	defer fake.closeMutex.RUnlock()
 	argsForCall := fake.closeArgsForCall[i]
@@ -343,11 +343,11 @@ func (fake *FakeProxyManager) RemoveDirReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeProxyManager) Update(arg1 containerstore.Credential, arg2 executor.Container) error {
+func (fake *FakeProxyManager) Update(arg1 containerstore.Credentials, arg2 executor.Container) error {
 	fake.updateMutex.Lock()
 	ret, specificReturn := fake.updateReturnsOnCall[len(fake.updateArgsForCall)]
 	fake.updateArgsForCall = append(fake.updateArgsForCall, struct {
-		arg1 containerstore.Credential
+		arg1 containerstore.Credentials
 		arg2 executor.Container
 	}{arg1, arg2})
 	stub := fake.UpdateStub
@@ -369,13 +369,13 @@ func (fake *FakeProxyManager) UpdateCallCount() int {
 	return len(fake.updateArgsForCall)
 }
 
-func (fake *FakeProxyManager) UpdateCalls(stub func(containerstore.Credential, executor.Container) error) {
+func (fake *FakeProxyManager) UpdateCalls(stub func(containerstore.Credentials, executor.Container) error) {
 	fake.updateMutex.Lock()
 	defer fake.updateMutex.Unlock()
 	fake.UpdateStub = stub
 }
 
-func (fake *FakeProxyManager) UpdateArgsForCall(i int) (containerstore.Credential, executor.Container) {
+func (fake *FakeProxyManager) UpdateArgsForCall(i int) (containerstore.Credentials, executor.Container) {
 	fake.updateMutex.RLock()
 	defer fake.updateMutex.RUnlock()
 	argsForCall := fake.updateArgsForCall[i]

--- a/depot/containerstore/instance_identity_handler.go
+++ b/depot/containerstore/instance_identity_handler.go
@@ -49,7 +49,7 @@ func (h *InstanceIdentityHandler) RemoveDir(logger lager.Logger, container execu
 	return os.RemoveAll(filepath.Join(h.credDir, container.Guid))
 }
 
-func (h *InstanceIdentityHandler) Update(cred Credential, container executor.Container) error {
+func (h *InstanceIdentityHandler) Update(creds Credentials, container executor.Container) error {
 	instanceKeyPath := filepath.Join(h.credDir, container.Guid, "instance.key")
 	tmpInstanceKeyPath := instanceKeyPath + ".tmp"
 	certificatePath := filepath.Join(h.credDir, container.Guid, "instance.crt")
@@ -67,12 +67,12 @@ func (h *InstanceIdentityHandler) Update(cred Credential, container executor.Con
 	}
 	defer certificate.Close()
 
-	_, err = certificate.Write([]byte(cred.Cert))
+	_, err = certificate.Write([]byte(creds.InstanceIdentityCredential.Cert))
 	if err != nil {
 		return err
 	}
 
-	_, err = instanceKey.Write([]byte(cred.Key))
+	_, err = instanceKey.Write([]byte(creds.InstanceIdentityCredential.Key))
 	if err != nil {
 		return err
 	}
@@ -100,6 +100,6 @@ func (h *InstanceIdentityHandler) Update(cred Credential, container executor.Con
 	return nil
 }
 
-func (h *InstanceIdentityHandler) Close(cred Credential, container executor.Container) error {
+func (h *InstanceIdentityHandler) Close(creds Credentials, container executor.Container) error {
 	return nil
 }

--- a/depot/containerstore/instance_identity_handler_test.go
+++ b/depot/containerstore/instance_identity_handler_test.go
@@ -83,7 +83,7 @@ var _ = Describe("InstanceIdentityHandler", func() {
 		})
 
 		It("puts private key into container directory", func() {
-			err := handler.Update(containerstore.Credential{Cert: "cert", Key: "key"}, container)
+			err := handler.Update(containerstore.Credentials{InstanceIdentityCredential: containerstore.Credential{Cert: "cert", Key: "key"}}, container)
 			Expect(err).NotTo(HaveOccurred())
 
 			certPath := filepath.Join(tmpdir, "some-guid")
@@ -97,7 +97,7 @@ var _ = Describe("InstanceIdentityHandler", func() {
 		})
 
 		It("puts the certificate into container directory", func() {
-			err := handler.Update(containerstore.Credential{Cert: "cert", Key: "key"}, container)
+			err := handler.Update(containerstore.Credentials{InstanceIdentityCredential: containerstore.Credential{Cert: "cert", Key: "key"}}, container)
 			Expect(err).NotTo(HaveOccurred())
 
 			certPath := filepath.Join(tmpdir, "some-guid")
@@ -115,12 +115,12 @@ var _ = Describe("InstanceIdentityHandler", func() {
 		BeforeEach(func() {
 			_, _, err := handler.CreateDir(logger, container)
 			Expect(err).To(BeNil())
-			err = handler.Update(containerstore.Credential{Cert: "cert", Key: "key"}, container)
+			err = handler.Update(containerstore.Credentials{InstanceIdentityCredential: containerstore.Credential{Cert: "cert", Key: "key"}}, container)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("does not put private key into container directory", func() {
-			err := handler.Close(containerstore.Credential{Cert: "invalid-cert", Key: "invalid-key"}, container)
+			err := handler.Close(containerstore.Credentials{InstanceIdentityCredential: containerstore.Credential{Cert: "invalid-cert", Key: "invalid-key"}}, container)
 			Expect(err).NotTo(HaveOccurred())
 
 			certPath := filepath.Join(tmpdir, "some-guid")
@@ -134,7 +134,7 @@ var _ = Describe("InstanceIdentityHandler", func() {
 		})
 
 		It("does not put the certificate into container directory", func() {
-			err := handler.Close(containerstore.Credential{Cert: "invalid-cert", Key: "invalid-key"}, container)
+			err := handler.Close(containerstore.Credentials{InstanceIdentityCredential: containerstore.Credential{Cert: "invalid-cert", Key: "invalid-key"}}, container)
 			Expect(err).NotTo(HaveOccurred())
 
 			certPath := filepath.Join(tmpdir, "some-guid")

--- a/depot/containerstore/proxy_config_handler.go
+++ b/depot/containerstore/proxy_config_handler.go
@@ -38,9 +38,10 @@ import (
 )
 
 const (
-	StartProxyPort = 61001
-	EndProxyPort   = 65534
-	C2CTLSPort     = 61443
+	StartProxyPort  = 61001
+	EndProxyPort    = 65534
+	DefaultHTTPPort = 8080
+	C2CTLSPort      = 61443
 
 	TimeOut = 250000000
 
@@ -49,6 +50,11 @@ const (
 	AdsClusterName  = "pilot-ads"
 
 	AdminAccessLog = os.DevNull
+
+	InstanceIdentityCertAndKeyFilename        = "sds-id-cert-and-key.yaml"
+	InstanceIdentityValidationContextFilename = "sds-id-validation-context.yaml"
+	C2CCertAndKeyFilename                     = "sds-c2c-cert-and-key.yaml"
+	ContainerEnvoyConfigDir                   = "/etc/cf-assets/envoy_config"
 )
 
 var (
@@ -97,10 +103,10 @@ func (p *NoopProxyConfigHandler) CreateDir(logger lager.Logger, container execut
 func (p *NoopProxyConfigHandler) RemoveDir(logger lager.Logger, container executor.Container) error {
 	return nil
 }
-func (p *NoopProxyConfigHandler) Update(credentials Credential, container executor.Container) error {
+func (p *NoopProxyConfigHandler) Update(credentials Credentials, container executor.Container) error {
 	return nil
 }
-func (p *NoopProxyConfigHandler) Close(invalidCredentials Credential, container executor.Container) error {
+func (p *NoopProxyConfigHandler) Close(invalidCredentials Credentials, container executor.Container) error {
 	return nil
 }
 
@@ -186,6 +192,14 @@ func (p *ProxyConfigHandler) ProxyPorts(logger lager.Logger, container *executor
 			ProxyPort: port,
 		})
 
+		if containerPorts[portCount] == DefaultHTTPPort {
+			proxyPortMapping = append(proxyPortMapping, executor.ProxyPortMapping{
+				AppPort:   containerPorts[portCount],
+				ProxyPort: C2CTLSPort,
+			})
+			extraPorts = append(extraPorts, C2CTLSPort)
+		}
+
 		portCount++
 	}
 
@@ -208,7 +222,7 @@ func (p *ProxyConfigHandler) CreateDir(logger lager.Logger, container executor.C
 		{
 			Origin:  garden.BindMountOriginHost,
 			SrcPath: proxyConfigDir,
-			DstPath: "/etc/cf-assets/envoy_config",
+			DstPath: ContainerEnvoyConfigDir,
 		},
 	}
 
@@ -230,7 +244,7 @@ func (p *ProxyConfigHandler) RemoveDir(logger lager.Logger, container executor.C
 	return os.RemoveAll(proxyConfigDir)
 }
 
-func (p *ProxyConfigHandler) Update(credentials Credential, container executor.Container) error {
+func (p *ProxyConfigHandler) Update(credentials Credentials, container executor.Container) error {
 	if !container.EnableContainerProxy {
 		return nil
 	}
@@ -238,7 +252,7 @@ func (p *ProxyConfigHandler) Update(credentials Credential, container executor.C
 	return p.writeConfig(credentials, container)
 }
 
-func (p *ProxyConfigHandler) Close(invalidCredentials Credential, container executor.Container) error {
+func (p *ProxyConfigHandler) Close(invalidCredentials Credentials, container executor.Container) error {
 	if !container.EnableContainerProxy {
 		return nil
 	}
@@ -252,10 +266,11 @@ func (p *ProxyConfigHandler) Close(invalidCredentials Credential, container exec
 	return nil
 }
 
-func (p *ProxyConfigHandler) writeConfig(credentials Credential, container executor.Container) error {
+func (p *ProxyConfigHandler) writeConfig(credentials Credentials, container executor.Container) error {
 	proxyConfigPath := filepath.Join(p.containerProxyConfigPath, container.Guid, "envoy.yaml")
-	sdsServerCertAndKeyPath := filepath.Join(p.containerProxyConfigPath, container.Guid, "sds-server-cert-and-key.yaml")
-	sdsServerValidationContextPath := filepath.Join(p.containerProxyConfigPath, container.Guid, "sds-server-validation-context.yaml")
+	sdsIDCertAndKeyPath := filepath.Join(p.containerProxyConfigPath, container.Guid, InstanceIdentityCertAndKeyFilename)
+	sdsC2CCertAndKeyPath := filepath.Join(p.containerProxyConfigPath, container.Guid, C2CCertAndKeyFilename)
+	sdsIDValidationContextPath := filepath.Join(p.containerProxyConfigPath, container.Guid, InstanceIdentityValidationContextFilename)
 
 	adminPort, err := getAvailablePort(container.Ports)
 	if err != nil {
@@ -278,22 +293,28 @@ func (p *ProxyConfigHandler) writeConfig(credentials Credential, container execu
 		return err
 	}
 
-	sdsServerCertAndKey := generateSDSCertAndKey(container, credentials)
-	err = writeDiscoveryResponseYAML(sdsServerCertAndKey, sdsServerCertAndKeyPath)
+	sdsIDCertAndKey := generateSDSCertAndKey("id-cert-and-key", credentials.InstanceIdentityCredential)
+	err = writeDiscoveryResponseYAML(sdsIDCertAndKey, sdsIDCertAndKeyPath)
 	if err != nil {
 		return err
 	}
 
-	sdsServerValidationContext, err := generateSDSCAResource(
+	sdsC2CCertAndKey := generateSDSCertAndKey("c2c-cert-and-key", credentials.C2CCredential)
+	err = writeDiscoveryResponseYAML(sdsC2CCertAndKey, sdsC2CCertAndKeyPath)
+	if err != nil {
+		return err
+	}
+
+	sdsIDValidationContext, err := generateSDSCAResource(
 		container,
-		credentials,
+		credentials.InstanceIdentityCredential,
 		p.containerProxyTrustedCACerts,
 		p.containerProxyVerifySubjectAltName,
 	)
 	if err != nil {
 		return err
 	}
-	err = writeDiscoveryResponseYAML(sdsServerValidationContext, sdsServerValidationContextPath)
+	err = writeDiscoveryResponseYAML(sdsIDValidationContext, sdsIDValidationContextPath)
 	if err != nil {
 		return err
 	}
@@ -322,8 +343,14 @@ func generateProxyConfig(
 	http2Enabled bool,
 ) (*envoy_bootstrap.Bootstrap, error) {
 	clusters := []*envoy_cluster.Cluster{}
-	for index, portMap := range container.Ports {
-		clusterName := fmt.Sprintf("%d-service-cluster", index)
+
+	uniqueContainerPorts := map[uint16]struct{}{}
+	for _, portMap := range container.Ports {
+		uniqueContainerPorts[portMap.ContainerPort] = struct{}{}
+	}
+
+	for containerPort := range uniqueContainerPorts {
+		clusterName := fmt.Sprintf("service-cluster-%d", containerPort)
 		clusters = append(clusters, &envoy_cluster.Cluster{
 			Name:                 clusterName,
 			ClusterDiscoveryType: &envoy_cluster.Cluster_Type{Type: envoy_cluster.Cluster_STATIC},
@@ -334,7 +361,7 @@ func generateProxyConfig(
 					LbEndpoints: []*envoy_endpoint.LbEndpoint{{
 						HostIdentifier: &envoy_endpoint.LbEndpoint_Endpoint{
 							Endpoint: &envoy_endpoint.Endpoint{
-								Address: envoyAddr(container.InternalIP, portMap.ContainerPort),
+								Address: envoyAddr(container.InternalIP, containerPort),
 							},
 						},
 					}},
@@ -461,12 +488,12 @@ func writeProxyConfig(proxyConfig *envoy_bootstrap.Bootstrap, path string) error
 func generateListeners(container executor.Container, requireClientCerts, http2Enabled bool) ([]*envoy_listener.Listener, error) {
 	listeners := []*envoy_listener.Listener{}
 
-	for index, portMap := range container.Ports {
+	for _, portMap := range container.Ports {
 		filterName := TcpProxy
-		clusterName := fmt.Sprintf("%d-service-cluster", index)
+		clusterName := fmt.Sprintf("service-cluster-%d", portMap.ContainerPort)
 
 		filterConfig, err := ptypes.MarshalAny(&envoy_tcp_proxy.TcpProxy{
-			StatPrefix: fmt.Sprintf("%d-stats", index),
+			StatPrefix: fmt.Sprintf("stats-%d-%d", portMap.ContainerPort, portMap.ContainerTLSProxyPort),
 			ClusterSpecifier: &envoy_tcp_proxy.TcpProxy_Cluster{
 				Cluster: clusterName,
 			},
@@ -475,15 +502,21 @@ func generateListeners(container executor.Container, requireClientCerts, http2En
 			return nil, err
 		}
 
+		sdsServerCertAndKeyFile := InstanceIdentityCertAndKeyFilename
+		sdsServerSecretName := "id-cert-and-key"
+		if portMap.ContainerTLSProxyPort == C2CTLSPort {
+			sdsServerCertAndKeyFile = C2CCertAndKeyFilename
+			sdsServerSecretName = "c2c-cert-and-key"
+		}
+
 		tlsContext := &envoy_tls.DownstreamTlsContext{
-			RequireClientCertificate: &wrappers.BoolValue{Value: requireClientCerts},
 			CommonTlsContext: &envoy_tls.CommonTlsContext{
 				TlsCertificateSdsSecretConfigs: []*envoy_tls.SdsSecretConfig{
 					{
-						Name: "server-cert-and-key",
+						Name: sdsServerSecretName,
 						SdsConfig: &envoy_core.ConfigSource{
 							ConfigSourceSpecifier: &envoy_core.ConfigSource_Path{
-								Path: "/etc/cf-assets/envoy_config/sds-server-cert-and-key.yaml",
+								Path: filepath.Join(ContainerEnvoyConfigDir, sdsServerCertAndKeyFile),
 							},
 						},
 					},
@@ -498,13 +531,14 @@ func generateListeners(container executor.Container, requireClientCerts, http2En
 			tlsContext.CommonTlsContext.AlpnProtocols = AlpnProtocols
 		}
 
-		if requireClientCerts {
+		if requireClientCerts && portMap.ContainerTLSProxyPort != C2CTLSPort {
+			tlsContext.RequireClientCertificate = &wrappers.BoolValue{Value: requireClientCerts}
 			tlsContext.CommonTlsContext.ValidationContextType = &envoy_tls.CommonTlsContext_ValidationContextSdsSecretConfig{
 				ValidationContextSdsSecretConfig: &envoy_tls.SdsSecretConfig{
-					Name: "server-validation-context",
+					Name: "id-validation-context",
 					SdsConfig: &envoy_core.ConfigSource{
 						ConfigSourceSpecifier: &envoy_core.ConfigSource_Path{
-							Path: "/etc/cf-assets/envoy_config/sds-server-validation-context.yaml",
+							Path: filepath.Join(ContainerEnvoyConfigDir, InstanceIdentityValidationContextFilename),
 						},
 					},
 				},
@@ -516,7 +550,7 @@ func generateListeners(container executor.Container, requireClientCerts, http2En
 			return nil, err
 		}
 
-		listenerName := fmt.Sprintf("listener-%d", portMap.ContainerPort)
+		listenerName := fmt.Sprintf("listener-%d-%d", portMap.ContainerPort, portMap.ContainerTLSProxyPort)
 		listener := &envoy_listener.Listener{
 			Name:    listenerName,
 			Address: envoyAddr("0.0.0.0", portMap.ContainerTLSProxyPort),
@@ -545,9 +579,9 @@ func generateListeners(container executor.Container, requireClientCerts, http2En
 	return listeners, nil
 }
 
-func generateSDSCertAndKey(container executor.Container, creds Credential) proto.Message {
+func generateSDSCertAndKey(name string, creds Credential) proto.Message {
 	return &envoy_tls.Secret{
-		Name: "server-cert-and-key",
+		Name: name,
 		Type: &envoy_tls.Secret_TlsCertificate{
 			TlsCertificate: &envoy_tls.TlsCertificate{
 				CertificateChain: &envoy_core.DataSource{
@@ -579,7 +613,7 @@ func generateSDSCAResource(container executor.Container, creds Credential, trust
 	}
 
 	return &envoy_tls.Secret{
-		Name: "server-validation-context",
+		Name: "id-validation-context",
 		Type: &envoy_tls.Secret_ValidationContext{
 			ValidationContext: &envoy_tls.CertificateValidationContext{
 				TrustedCa: &envoy_core.DataSource{

--- a/resources.go
+++ b/resources.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"code.cloudfoundry.org/bbs/models"
+	"code.cloudfoundry.org/routing-info/internalroutes"
 )
 
 const ContainerOwnerProperty = "executor:owner"
@@ -165,28 +166,29 @@ type Sidecar struct {
 }
 
 type RunInfo struct {
-	RootFSPath                    string                      `json:"rootfs"`
-	CPUWeight                     uint                        `json:"cpu_weight"`
-	Ports                         []PortMapping               `json:"ports"`
-	LogConfig                     LogConfig                   `json:"log_config"`
-	MetricsConfig                 MetricsConfig               `json:"metrics_config"`
-	StartTimeoutMs                uint                        `json:"start_timeout_ms"`
-	Privileged                    bool                        `json:"privileged"`
-	CachedDependencies            []CachedDependency          `json:"cached_dependencies"`
-	Setup                         *models.Action              `json:"setup"`
-	Action                        *models.Action              `json:"run"`
-	Monitor                       *models.Action              `json:"monitor"`
-	CheckDefinition               *models.CheckDefinition     `json:"check_definition"`
-	EgressRules                   []*models.SecurityGroupRule `json:"egress_rules,omitempty"`
-	Env                           []EnvironmentVariable       `json:"env,omitempty"`
-	TrustedSystemCertificatesPath string                      `json:"trusted_system_certificates_path,omitempty"`
-	VolumeMounts                  []VolumeMount               `json:"volume_mounts"`
-	Network                       *Network                    `json:"network,omitempty"`
-	CertificateProperties         CertificateProperties       `json:"certificate_properties"`
-	ImageUsername                 string                      `json:"image_username"`
-	ImagePassword                 string                      `json:"image_password"`
-	EnableContainerProxy          bool                        `json:"enable_container_proxy"`
-	Sidecars                      []Sidecar                   `json:"sidecars"`
+	RootFSPath                    string                        `json:"rootfs"`
+	CPUWeight                     uint                          `json:"cpu_weight"`
+	Ports                         []PortMapping                 `json:"ports"`
+	InternalRoutes                internalroutes.InternalRoutes `json:"internal_routes"`
+	LogConfig                     LogConfig                     `json:"log_config"`
+	MetricsConfig                 MetricsConfig                 `json:"metrics_config"`
+	StartTimeoutMs                uint                          `json:"start_timeout_ms"`
+	Privileged                    bool                          `json:"privileged"`
+	CachedDependencies            []CachedDependency            `json:"cached_dependencies"`
+	Setup                         *models.Action                `json:"setup"`
+	Action                        *models.Action                `json:"run"`
+	Monitor                       *models.Action                `json:"monitor"`
+	CheckDefinition               *models.CheckDefinition       `json:"check_definition"`
+	EgressRules                   []*models.SecurityGroupRule   `json:"egress_rules,omitempty"`
+	Env                           []EnvironmentVariable         `json:"env,omitempty"`
+	TrustedSystemCertificatesPath string                        `json:"trusted_system_certificates_path,omitempty"`
+	VolumeMounts                  []VolumeMount                 `json:"volume_mounts"`
+	Network                       *Network                      `json:"network,omitempty"`
+	CertificateProperties         CertificateProperties         `json:"certificate_properties"`
+	ImageUsername                 string                        `json:"image_username"`
+	ImagePassword                 string                        `json:"image_password"`
+	EnableContainerProxy          bool                          `json:"enable_container_proxy"`
+	Sidecars                      []Sidecar                     `json:"sidecars"`
 }
 
 type BindMountMode uint8


### PR DESCRIPTION
Add another listener to Envoy that proxies port 61443 to 8080 inside of
container. It serves the SSL certificate that contains SAN with all
application internal routes.

[#180173340](https://www.pivotaltracker.com/story/show/180173340)
