### PR TITLE
Fix healthcheck logging

### DIFF
--- a/depot/log_streamer/concurrent_buffer.go
+++ b/depot/log_streamer/concurrent_buffer.go
@@ -6,7 +6,7 @@ import (
 )
 
 type ConcurrentBuffer struct {
-	*bytes.Buffer
+	Buffer *bytes.Buffer
 	*sync.Mutex
 }
 

--- a/depot/log_streamer/concurrent_buffer_test.go
+++ b/depot/log_streamer/concurrent_buffer_test.go
@@ -14,7 +14,9 @@ var _ = Describe("concurrent buffer", func() {
 	Describe("NewConcurrentBuffer", func() {
 		It("creates a new concurrent buffer out of the given payload", func() {
 			payload := bytes.NewBuffer([]byte{3, 4, 5})
-			Expect(log_streamer.NewConcurrentBuffer(payload).String()).To(BeEquivalentTo(payload.String()))
+			content, err := io.ReadAll(log_streamer.NewConcurrentBuffer(payload))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(content).To(Equal([]byte{3, 4, 5}))
 		})
 
 		It("return nil if the payload is nil", func() {

--- a/depot/steps/health_check_step.go
+++ b/depot/steps/health_check_step.go
@@ -85,7 +85,7 @@ func (step *healthCheckStep) Run(signals <-chan os.Signal, ready chan<- struct{}
 	case err := <-livenessProcess.Wait():
 		step.logger.Info("transitioned-to-unhealthy")
 		fmt.Fprintf(step.healthCheckStreamer.Stderr(), "%s\n", err.Error())
-		fmt.Fprint(step.logStreamer.Stdout(), "Container became unhealthy\n")
+		fmt.Fprint(step.logStreamer.Stderr(), "Container became unhealthy\n")
 		return NewEmittableError(err, healthcheckNowUnhealthy, err.Error())
 	case s := <-signals:
 		livenessProcess.Signal(s)

--- a/depot/steps/health_check_step_test.go
+++ b/depot/steps/health_check_step_test.go
@@ -146,7 +146,7 @@ var _ = Describe("NewHealthCheckStep", func() {
 				})
 
 				It("emits a log message for the failure", func() {
-					Eventually(fakeStreamer.Stdout().(*gbytes.Buffer)).Should(
+					Eventually(fakeStreamer.Stderr().(*gbytes.Buffer)).Should(
 						gbytes.Say("Container became unhealthy\n"),
 					)
 				})

--- a/depot/steps/monitor_step_test.go
+++ b/depot/steps/monitor_step_test.go
@@ -194,8 +194,8 @@ var _ = Describe("MonitorStep", func() {
 							}))
 						})
 
-						It("emits a log message for the success", func() {
-							Eventually(fakeStreamer.Stdout().(*gbytes.Buffer)).Should(
+						It("emits a log message for the failure", func() {
+							Eventually(fakeStreamer.Stderr().(*gbytes.Buffer)).Should(
 								gbytes.Say("Container became unhealthy\n"),
 							)
 						})

--- a/depot/steps/output_wrapper_step.go
+++ b/depot/steps/output_wrapper_step.go
@@ -1,6 +1,7 @@
 package steps
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -39,18 +40,18 @@ func (step *outputWrapperStep) Run(signals <-chan os.Signal, ready chan<- struct
 
 	bytes, err := ioutil.ReadAll(step.reader)
 	if err != nil {
-		return err
+		return fmt.Errorf("Error reading from process output buffer: %s", err)
 	}
+
+	msg := fmt.Sprintf("Failed to invoke process: %s", subStepErr)
 
 	readerErr := string(bytes)
 	if readerErr != "" {
-		msg := strings.TrimSpace(readerErr)
-		if step.prefix != "" {
-			msg = step.prefix + ": " + msg
-		}
-		return NewEmittableError(nil, msg)
+		msg = strings.TrimSpace(readerErr)
 	}
 
-	return subStepErr
-
+	if step.prefix != "" {
+		msg = step.prefix + ": " + msg
+	}
+	return NewEmittableError(subStepErr, msg)
 }

--- a/depot/steps/output_wrapper_step_test.go
+++ b/depot/steps/output_wrapper_step_test.go
@@ -83,7 +83,7 @@ var _ = Describe("OutputWrapperStep", func() {
 
 			It("returns the CancelledError error", func() {
 				p := ifrit.Background(step)
-				Eventually(p.Wait()).Should(Receive(MatchError(new(steps.CancelledError))))
+				Eventually(p.Wait()).Should(Receive(MatchError(steps.NewEmittableError(new(steps.CancelledError), "Failed to invoke process: cancelled"))))
 			})
 
 			Context("and the buffer has data", func() {

--- a/depot/transformer/transformer.go
+++ b/depot/transformer/transformer.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -244,7 +243,7 @@ func (t *transformer) stepFor(
 			var subStep ifrit.Runner
 			if monitorOutputWrapper {
 				buffer := log_streamer.NewConcurrentBuffer(bytes.NewBuffer(nil))
-				bufferedLogStreamer := log_streamer.NewBufferStreamer(buffer, ioutil.Discard)
+				bufferedLogStreamer := log_streamer.NewBufferStreamer(buffer, buffer)
 				subStep = steps.NewOutputWrapper(t.stepFor(
 					bufferedLogStreamer,
 					action,
@@ -281,7 +280,7 @@ func (t *transformer) stepFor(
 			var subStep ifrit.Runner
 			if monitorOutputWrapper {
 				buffer := log_streamer.NewConcurrentBuffer(bytes.NewBuffer(nil))
-				bufferedLogStreamer := log_streamer.NewBufferStreamer(buffer, ioutil.Discard)
+				bufferedLogStreamer := log_streamer.NewBufferStreamer(buffer, buffer)
 				subStep = steps.NewOutputWrapper(t.stepFor(
 					bufferedLogStreamer,
 					action,
@@ -578,8 +577,8 @@ func (t *transformer) createCheck(
 		Args:           args,
 	}
 
-	buffer := bytes.NewBuffer(nil)
-	bufferedLogStreamer := log_streamer.NewBufferStreamer(buffer, ioutil.Discard)
+	buffer := log_streamer.NewConcurrentBuffer(bytes.NewBuffer(nil))
+	bufferedLogStreamer := log_streamer.NewBufferStreamer(buffer, buffer)
 	sidecar := steps.Sidecar{
 		Name:                    sidecarName,
 		Image:                   garden.ImageRef{URI: t.sidecarRootFS},


### PR DESCRIPTION
Resolves a few bugs related to healthcheck logging.
1. healthcheck output going to stderr was being ignored completely. On windows, this source of information is important for debugging certain reasons why processes fail to start, as errors are sometimes returned here with exit code 1, rather than a failure to spawn the process
2. healthcheck output was sometimes being dropped completely. The changes to concurrentbuffer should rectify this.
3. this PR also clarifies the failure modes encountered when running health checks, to better understand where failure messages are coming from