### PR TITLE
Fix log rate limiting when the line is empty

### DIFF
--- a/depot/log_streamer/log_streamer_test.go
+++ b/depot/log_streamer/log_streamer_test.go
@@ -78,7 +78,7 @@ var _ = Describe("LogStreamer", func() {
 
 					logLine := strings.Repeat("a", int(maxLogBytesPerSecond/2))
 					for i := 0; i < 3; i++ {
-						go fmt.Fprintf(streamer.Stdout(), logLine+"\n", i)
+						go fmt.Fprintf(streamer.Stdout(), logLine+"\n\n\n\n", i)
 					}
 				})
 

--- a/depot/log_streamer/stream_destination.go
+++ b/depot/log_streamer/stream_destination.go
@@ -55,12 +55,10 @@ func (destination *streamDestination) Write(data []byte) (int, error) {
 func (destination *streamDestination) flush() {
 	msg := destination.copyAndResetBuffer()
 
-	err := destination.logRateLimiter.Limit(destination.sourceName, len(msg))
-	if err != nil {
-		return
-	}
-
 	if len(msg) > 0 {
+		if destination.logRateLimiter.Limit(destination.sourceName, len(msg)) != nil {
+			return
+		}
 		switch destination.messageType {
 		case loggregator_v2.Log_OUT:
 			_ = destination.metronClient.SendAppLog(string(msg), destination.sourceName, destination.tags)


### PR DESCRIPTION
### What is this change about?

- stack traces seem to print out poorly because of newlines creating empty sized lines. This seems to always reset the error messages which results in a overload of over quota messages

### What problem it is trying to solve?

We wrote log-rate messages too many times

### What is the impact if the change is not made?

we'll emit too much log rate messages

### How should this change be described in Diego-release release notes?

Fixed a bug where Diego could report going over the rate limit too many times.
