### PR TITLE
Timeout implementation of reducing overage logs. 

### DIFF
--- a/depot/log_streamer/log_rate_limiter_test.go
+++ b/depot/log_streamer/log_rate_limiter_test.go
@@ -59,7 +59,7 @@ var _ = Describe("LogRateLimiter", func() {
 		Expect(counterName).To(Equal("AppInstanceExceededLogRateLimitCount"))
 	})
 
-	It("does not report over limit message too much", func() {
+	It("blocks messages for an entire second with only one report if limit reached", func() {
 		ctx := context.Background()
 		fakeClient := &mfakes.FakeIngressClient{}
 		logRateLimiter := log_streamer.NewLogRateLimiter(ctx, fakeClient, map[string]string{}, 2, 100, time.Hour)
@@ -70,11 +70,11 @@ var _ = Describe("LogRateLimiter", func() {
 		Expect(fakeClient.SendAppLogCallCount()).To(Equal(1))
 		Expect(logRateLimiter.Limit("test", 100000)).To(HaveOccurred())
 		Expect(fakeClient.SendAppLogCallCount()).To(Equal(1))
-		Expect(logRateLimiter.Limit("test", 5)).ToNot(HaveOccurred())
+		Expect(logRateLimiter.Limit("test", 5)).To(HaveOccurred())
 		Expect(fakeClient.SendAppLogCallCount()).To(Equal(1))
 		Expect(logRateLimiter.Limit("test", 100000)).To(HaveOccurred())
 		Expect(fakeClient.SendAppLogCallCount()).To(Equal(1))
-		time.Sleep(time.Second)
+		time.Sleep(time.Millisecond * 1100)
 		Expect(logRateLimiter.Limit("test", 100000)).To(HaveOccurred())
 		Expect(fakeClient.SendAppLogCallCount()).To(Equal(2))
 	})

--- a/depot/log_streamer/log_streamer_test.go
+++ b/depot/log_streamer/log_streamer_test.go
@@ -136,8 +136,8 @@ var _ = Describe("LogStreamer", func() {
 				fmt.Fprintf(streamer.Stdout(), "bbbbbbb\n")
 			})
 
-			It("skips logs which exceed the burst capacity", func() {
-				Eventually(fakeClient.SendAppLogCallCount, 1*time.Second).Should(Equal(2))
+			It("causes outages of logs", func() {
+				Eventually(fakeClient.SendAppLogCallCount, 1*time.Second).Should(Equal(1))
 
 				var messages []string
 				for i := 0; i < fakeClient.SendAppLogCallCount(); i++ {
@@ -146,7 +146,6 @@ var _ = Describe("LogStreamer", func() {
 				}
 
 				Expect(messages).To(ConsistOf(
-					MatchRegexp("^b+$"),
 					Equal("app instance exceeded log rate limit (100 bytes/sec)"),
 				))
 			})


### PR DESCRIPTION
does most of what this does https://github.com/cloudfoundry/executor/pull/72, but gives the app a 1s timeout instead of just limiting the amount of warnings. 