### PR TITLE
Executor updates garden metadata

### DIFF
--- a/depot/containerstore/containerstore.go
+++ b/depot/containerstore/containerstore.go
@@ -251,9 +251,7 @@ func (cs *containerStore) Update(logger lager.Logger, req *executor.UpdateReques
 		return err
 	}
 
-	node.Update(logger, req)
-
-	return nil
+	return node.Update(logger, req)
 }
 
 func (cs *containerStore) Stop(logger lager.Logger, guid string) error {

--- a/depot/containerstore/containerstore.go
+++ b/depot/containerstore/containerstore.go
@@ -88,6 +88,8 @@ type containerStore struct {
 
 	enableUnproxiedPortMappings           bool
 	advertisePreferenceForInstanceAddress bool
+
+	jsonMarshaller func(any) ([]byte, error)
 }
 
 func New(
@@ -110,6 +112,7 @@ func New(
 	cellID string,
 	enableUnproxiedPortMappings bool,
 	advertisePreferenceForInstanceAddress bool,
+	jsonMarshaller func(any) ([]byte, error),
 ) ContainerStore {
 	return &containerStore{
 		containerConfig:               containerConfig,
@@ -133,6 +136,7 @@ func New(
 
 		enableUnproxiedPortMappings:           enableUnproxiedPortMappings,
 		advertisePreferenceForInstanceAddress: advertisePreferenceForInstanceAddress,
+		jsonMarshaller:                        jsonMarshaller,
 	}
 }
 
@@ -167,6 +171,7 @@ func (cs *containerStore) Reserve(logger lager.Logger, req *executor.AllocationR
 			cs.cellID,
 			cs.enableUnproxiedPortMappings,
 			cs.advertisePreferenceForInstanceAddress,
+			cs.jsonMarshaller,
 		))
 
 	if err != nil {

--- a/depot/containerstore/containerstore_test.go
+++ b/depot/containerstore/containerstore_test.go
@@ -160,6 +160,7 @@ var _ = Describe("Container Store", func() {
 			cellID,
 			true,
 			advertisePreferenceForInstanceAddress,
+			json.Marshal,
 		)
 
 		metronClient.SendDurationStub = func(name string, value time.Duration, opts ...loggregator.EmitGaugeOption) error {
@@ -485,6 +486,7 @@ var _ = Describe("Container Store", func() {
 						cellID,
 						true,
 						advertisePreferenceForInstanceAddress,
+						json.Marshal,
 					)
 				})
 
@@ -706,6 +708,7 @@ var _ = Describe("Container Store", func() {
 						cellID,
 						true,
 						advertisePreferenceForInstanceAddress,
+						json.Marshal,
 					)
 				})
 
@@ -1194,6 +1197,7 @@ var _ = Describe("Container Store", func() {
 						cellID,
 						true,
 						advertisePreferenceForInstanceAddress,
+						json.Marshal,
 					)
 
 					portMapping := []executor.PortMapping{
@@ -1283,6 +1287,7 @@ var _ = Describe("Container Store", func() {
 							cellID,
 							false,
 							advertisePreferenceForInstanceAddress,
+							json.Marshal,
 						)
 					})
 
@@ -2231,6 +2236,45 @@ var _ = Describe("Container Store", func() {
 				})
 			})
 
+			Context("when the log config cannot be serialized", func() {
+				var fm failingMarshaller
+
+				BeforeEach(func() {
+					containerStore = containerstore.New(
+						containerConfig,
+						&totalCapacity,
+						gardenClient,
+						dependencyManager,
+						volumeManager,
+						credManager,
+						logManager,
+						clock,
+						eventEmitter,
+						megatron,
+						"/var/vcap/data/cf-system-trusted-certs",
+						metronClient,
+						rootFSSizer,
+						false,
+						"/var/vcap/packages/healthcheck",
+						proxyManager,
+						cellID,
+						true,
+						advertisePreferenceForInstanceAddress,
+						fm.Marshal,
+					)
+				})
+
+				It("releases the info lock", func() {
+					fm.fail = true
+					err := containerStore.Update(logger, updateReq)
+					Expect(err).To(HaveOccurred())
+
+					fm.fail = false
+					err = containerStore.Update(logger, updateReq)
+					Expect(err).NotTo(HaveOccurred())
+				})
+			})
+
 			Context("when there is an error updating the log config property on the container", func() {
 				BeforeEach(func() {
 					gardenContainer.SetPropertyReturns(errors.New("some-error"))
@@ -2786,6 +2830,7 @@ var _ = Describe("Container Store", func() {
 						cellID,
 						true,
 						advertisePreferenceForInstanceAddress,
+						json.Marshal,
 					)
 
 					signalled := credManagerRunnerSignalled
@@ -3365,3 +3410,14 @@ var _ = Describe("Container Store", func() {
 		})
 	})
 })
+
+type failingMarshaller struct {
+	fail bool
+}
+
+func (m *failingMarshaller) Marshal(v any) ([]byte, error) {
+	if m.fail {
+		return []byte{}, errors.New("marshalling failed")
+	}
+	return json.Marshal(v)
+}

--- a/depot/containerstore/storenode.go
+++ b/depot/containerstore/storenode.go
@@ -178,7 +178,7 @@ func (n *storeNode) Initialize(logger lager.Logger, req *executor.RunRequest) er
 	n.infoLock.Lock()
 	defer n.infoLock.Unlock()
 
-	err := n.info.TransistionToInitialize(req)
+	err := n.info.TransitionToInitialize(req)
 	if err != nil {
 		logger.Error("failed-to-initialize", err)
 		return err

--- a/initializer/initializer.go
+++ b/initializer/initializer.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"encoding/pem"
 	"errors"
 	"fmt"
@@ -328,6 +329,7 @@ func Initialize(logger lager.Logger, config ExecutorConfig, cellID, zone string,
 		cellID,
 		config.EnableUnproxiedPortMappings,
 		config.AdvertisePreferenceForInstanceAddress,
+		json.Marshal,
 	)
 
 	depotClient := depot.NewClient(

--- a/resources.go
+++ b/resources.go
@@ -72,7 +72,7 @@ func (c *Container) ValidateTransitionTo(newState State) bool {
 	}
 }
 
-func (c *Container) TransistionToInitialize(req *RunRequest) error {
+func (c *Container) TransitionToInitialize(req *RunRequest) error {
 	if !c.ValidateTransitionTo(StateInitializing) {
 		return ErrInvalidTransition
 	}


### PR DESCRIPTION
## Please provide the following information:


### What is this change about?

Executor updates garden metadata so that silk can get updated metadata for logging

### What problem it is trying to solve?

silk sometimes will log dynamic asg info with the wrong metadata if this isn't done. 

### What is the impact if the change is not made?

silk sometimes will log dynamic asg info with the wrong metadata if this isn't done. 

### How should this change be described in diego-release release notes?

Fixed diego to enable silk to log with correct metadata