### PR TITLE
Improve container tracking when containers failing to be created/destroyed in garden

### DIFF
--- a/depot/containerstore/containerstore.go
+++ b/depot/containerstore/containerstore.go
@@ -288,11 +288,12 @@ func (cs *containerStore) Destroy(logger lager.Logger, guid string) error {
 	err = node.Destroy(logger)
 	if err != nil {
 		logger.Error("failed-to-destroy-container", err)
+		return err
 	}
 
 	cs.containers.Remove(guid)
 
-	return err
+	return nil
 }
 
 func (cs *containerStore) Get(logger lager.Logger, guid string) (executor.Container, error) {

--- a/depot/containerstore/storenode.go
+++ b/depot/containerstore/storenode.go
@@ -645,7 +645,9 @@ func (n *storeNode) stop(logger lager.Logger) {
 		n.process.Signal(os.Interrupt)
 		logger.Debug("signalled-process")
 	} else {
-		n.complete(logger, true, "stopped-before-running", false)
+		if n.info.State != executor.StateCompleted {
+			n.complete(logger, true, "stopped-before-running", false)
+		}
 	}
 }
 

--- a/initializer/initializer.go
+++ b/initializer/initializer.go
@@ -61,6 +61,7 @@ type executorContainers struct {
 func (containers *executorContainers) Containers() ([]garden.Container, error) {
 	return containers.gardenClient.Containers(garden.Properties{
 		executor.ContainerOwnerProperty: containers.owner,
+		executor.ContainerStateProperty: "all",
 	})
 }
 

--- a/initializer/initializer_test.go
+++ b/initializer/initializer_test.go
@@ -185,6 +185,9 @@ var _ = Describe("Initializer", func() {
 			fakeGarden.RouteToHandler("GET", "/containers",
 				func(w http.ResponseWriter, r *http.Request) {
 					r.ParseForm()
+					gardenState := r.URL.Query()["garden.state"]
+					Expect(gardenState).To(HaveLen(1))
+					Expect(gardenState[0]).To(Equal("all"))
 					healthcheckTagQueryParam := gardenhealth.HealthcheckTag
 					if r.FormValue(healthcheckTagQueryParam) == gardenhealth.HealthcheckTagValue {
 						ghttp.RespondWithJSONEncoded(http.StatusOK, struct{}{})(w, r)

--- a/resources.go
+++ b/resources.go
@@ -10,7 +10,10 @@ import (
 	"code.cloudfoundry.org/routing-info/internalroutes"
 )
 
-const ContainerOwnerProperty = "executor:owner"
+const (
+	ContainerOwnerProperty = "executor:owner"
+	ContainerStateProperty = "garden.state"
+)
 
 type State string
 


### PR DESCRIPTION
### What is this change about?

This PR helps with the issue when containers are failing to be created and destroyed:
- not to release resources when destroying container fails
- being able to clean up all containers when it was partially created

### What problem it is trying to solve?

For example when the networker is down, both garden create and destroy will be failing.

When we destroy container we want to make sure that if we fail to destroy we do not release available resources. Releasing available resources will result in more work to be scheduled on that Diego cell and eventually hitting other limits, like max container limit in garden.

When rep is staring and performing clean up we want to account for containers that were partially created (`garden.state` is not set to `created`). 

### What is the impact if the change is not made?

Containers that are not fully created will be leaked by rep. Eventually rep will overschedule work and hit the limits like max container reached. These containers won't be cleaned up when rep is restarted. 

There is an option in garden to clean up all containers but it is optional.

### How should this change be described in diego-release release notes?

Improve container tracking when containers failing to be created/destroyed in garden

### Please provide any contextual information.

Related change in garden - https://github.com/cloudfoundry/guardian/pull/371

Garden change is not required, since it is backwards compatible. Setting garden.state in Rep is not going to have any effect in old garden (it overwrites garden.state as created).

### Tag your pair, your PM, and/or team!

@reneighbor 

Thank you!
