### PR TITLE
Run readiness health checks

### DIFF
--- a/depot/containerstore/containerstore_test.go
+++ b/depot/containerstore/containerstore_test.go
@@ -1814,13 +1814,13 @@ var _ = Describe("Container Store", func() {
 								Eventually(logger).Should(gbytes.Say("Got IsNotReady message"))
 							})
 							FIt("emits a container not ready event", func() {
-								// info := executor.Container{}
-								// info.State = executor.StateReserved // TODO replace me,
-								// implement info.Condition and executor.ConditionNotReady
+								container, err := containerStore.Get(logger, containerGuid)
+								Expect(err).NotTo(HaveOccurred())
+								Expect(container.Condition).To(BeEquivalentTo(executor.ConditionNotReady))
 
 								Eventually(eventEmitter.EmitCallCount).Should(Equal(3))
 								event := eventEmitter.EmitArgsForCall(2)
-								Expect(event.EventType()).To(Equal(executor.EventTypeContainerComplete))
+								Expect(event.EventType()).To(Equal(executor.EventTypeContainerNotReady))
 							})
 
 						})

--- a/depot/containerstore/containerstore_test.go
+++ b/depot/containerstore/containerstore_test.go
@@ -1362,7 +1362,7 @@ var _ = Describe("Container Store", func() {
 					}), nil)
 					Expect(containerStore.Run(logger, "some-trace-id", containerGuid)).NotTo(HaveOccurred())
 					Eventually(megatron.StepsRunnerCallCount).Should(Equal(1))
-					_, _, _, _, cfg := megatron.StepsRunnerArgsForCall(0)
+					_, _, _, _, _, cfg := megatron.StepsRunnerArgsForCall(0)
 					Expect(cfg.ProxyTLSPorts).To(ConsistOf(uint16(61001), uint16(61002), uint16(containerstore.C2CTLSPort)))
 				})
 

--- a/depot/containerstore/storenode.go
+++ b/depot/containerstore/storenode.go
@@ -582,10 +582,13 @@ func (n *storeNode) monitorReadiness(logger lager.Logger, readinessCh chan steps
 			if msg == steps.IsNotReady {
 				logger.Info("Got IsNotReady message")
 				fmt.Fprint(logStreamer.Stdout(), "Store node sees that app is not ready!\n")
+				n.infoLock.Lock()
+				n.eventEmitter.Emit(executor.NewContainerReservedEvent(n.info)) //TODO replace with condition. Also, does this need to be in a goroutine?
+				n.infoLock.Unlock()                                             // Does this need to be in a defer?
+				//	return return was needed when unlock() was in a defer
 			}
 			if msg == steps.IsReady {
 				logger.Info("Got IsReady message")
-				fmt.Fprint(logStreamer.Stdout(), "Store node sees that app is ready!\n")
 			}
 		}
 	}

--- a/depot/containerstore/storenode.go
+++ b/depot/containerstore/storenode.go
@@ -526,7 +526,8 @@ func (n *storeNode) Run(logger lager.Logger, traceID string) error {
 		CreationStartTime: n.startTime,
 		MetronClient:      n.metronClient,
 	}
-	runner, err := n.transformer.StepsRunner(logger, n.info, n.gardenContainer, n.logStreamer, cfg)
+	readinessChan := make(chan steps.ReadinessState, 10) // todo replace buffer with reader for channel
+	runner, err := n.transformer.StepsRunner(logger, n.info, n.gardenContainer, readinessChan, n.logStreamer, cfg)
 	if err != nil {
 		return err
 	}

--- a/depot/containerstore/storenode.go
+++ b/depot/containerstore/storenode.go
@@ -583,7 +583,8 @@ func (n *storeNode) monitorReadiness(logger lager.Logger, readinessCh chan steps
 				logger.Info("Got IsNotReady message")
 				fmt.Fprint(logStreamer.Stdout(), "Store node sees that app is not ready!\n")
 				n.infoLock.Lock()
-				n.eventEmitter.Emit(executor.NewContainerReservedEvent(n.info)) //TODO replace with condition. Also, does this need to be in a goroutine?
+				n.info.Condition = executor.ConditionNotReady
+				n.eventEmitter.Emit(executor.NewContainerNotReadyEvent(n.info)) //TODO replace with condition. Also, does this need to be in a goroutine?
 				n.infoLock.Unlock()                                             // Does this need to be in a defer?
 				//	return return was needed when unlock() was in a defer
 			}
@@ -610,7 +611,7 @@ func (n *storeNode) run(logger lager.Logger, readinessCh chan steps.ReadinessSta
 	logger.Debug("healthcheck-passed")
 
 	n.infoLock.Lock()
-	n.info.State = executor.StateRunning
+	n.info.Condition = executor.ConditionNotReady
 	info := n.info.Copy()
 	n.infoLock.Unlock()
 	go n.eventEmitter.Emit(executor.NewContainerRunningEvent(info, traceID))

--- a/depot/steps/monitor_step_test.go
+++ b/depot/steps/monitor_step_test.go
@@ -259,7 +259,7 @@ var _ = Describe("MonitorStep", func() {
 					expectCheckAfterInterval(fakeStep1, unhealthyInterval)
 					expectCheckAfterInterval(fakeStep2, unhealthyInterval)
 					Eventually(fakeStreamer.Stderr().(*gbytes.Buffer)).Should(gbytes.Say(
-						"Failed after .*: readiness health check never passed.\n",
+						"Failed after .*: startup health check never passed.\n",
 					))
 				})
 			})

--- a/depot/steps/parallel_step_test.go
+++ b/depot/steps/parallel_step_test.go
@@ -106,7 +106,7 @@ var _ = Describe("ParallelStep", func() {
 		})
 	})
 
-	Describe("readiness", func() {
+	Describe("process readiness", func() {
 		It("does not become ready until its subprocesses are", func() {
 			Consistently(process.Ready()).ShouldNot(BeClosed())
 

--- a/depot/steps/readiness_health_check_step.go
+++ b/depot/steps/readiness_health_check_step.go
@@ -62,7 +62,7 @@ func (step *readinessHealthCheckStep) runUntilReadyProcess(signals <-chan os.Sig
 	select {
 	case err := <-untilReadyProcess.Wait():
 		if err != nil {
-			fmt.Fprint(step.logStreamer.Stdout(), "Failed to run the readiness check\n")
+			fmt.Fprint(step.logStreamer.Stdout(), "Container passed the readiness health check. Container marked ready and added to route pool.\n")
 			return err
 		}
 		step.logger.Info("transitioned-to-ready")
@@ -82,7 +82,7 @@ func (step *readinessHealthCheckStep) runUntilFailureProcess(signals <-chan os.S
 	case err := <-untilFailureProcess.Wait():
 		if err != nil {
 			step.logger.Info("transitioned-to-not-ready")
-			fmt.Fprint(step.logStreamer.Stdout(), "Container became not ready\n")
+			fmt.Fprint(step.logStreamer.Stdout(), "Container failed the readiness health check. Container marked not ready and removed from route pool.\n")
 			step.readinessChan <- IsNotReady
 			return nil
 		}

--- a/depot/steps/readiness_health_check_step.go
+++ b/depot/steps/readiness_health_check_step.go
@@ -1,0 +1,86 @@
+package steps
+
+import (
+	"fmt"
+	"os"
+
+	"code.cloudfoundry.org/executor/depot/log_streamer"
+	"github.com/tedsuo/ifrit"
+)
+
+type readinessHealthCheckStep struct {
+	untilReadyCheck   ifrit.Runner
+	untilFailureCheck ifrit.Runner
+	logStreamer       log_streamer.LogStreamer
+}
+
+func NewReadinessHealthCheckStep(
+	untilReadyCheck ifrit.Runner,
+	untilFailureCheck ifrit.Runner,
+	logStreamer log_streamer.LogStreamer,
+) ifrit.Runner {
+	return &readinessHealthCheckStep{
+		untilReadyCheck:   untilReadyCheck,
+		untilFailureCheck: untilFailureCheck,
+		logStreamer:       logStreamer,
+	}
+}
+
+func (step *readinessHealthCheckStep) Run(signals <-chan os.Signal, ready chan<- struct{}) error {
+	fmt.Fprint(step.logStreamer.Stdout(), "Starting readiness health monitoring of container\n")
+
+	err := step.runUntilReadyProcess(signals)
+	if err != nil {
+		return err
+	}
+
+	close(ready)
+
+	err = step.runUntilFailureProcess(signals)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (step *readinessHealthCheckStep) runUntilReadyProcess(signals <-chan os.Signal) error {
+	untilReadyProcess := ifrit.Background(step.untilReadyCheck)
+	select {
+	case err := <-untilReadyProcess.Wait():
+		if err != nil {
+			fmt.Fprint(step.logStreamer.Stdout(), "Failed to run the untilReady check\n")
+			return err
+		}
+		fmt.Fprint(step.logStreamer.Stdout(), "App is ready!\n")
+		return nil
+	case s := <-signals:
+		untilReadyProcess.Signal(s)
+		<-untilReadyProcess.Wait()
+		return new(CancelledError)
+	}
+}
+
+func (step *readinessHealthCheckStep) runUntilFailureProcess(signals <-chan os.Signal) error {
+	untilFailureProcess := ifrit.Background(step.untilFailureCheck)
+	select {
+	case err := <-untilFailureProcess.Wait():
+		if err != nil {
+			fmt.Fprint(step.logStreamer.Stdout(), "Oh no! The app is not ready anymore\n")
+			return nil
+		}
+		return nil // TODO: would this case ever happen? how should we handle this?
+	case s := <-signals:
+		untilFailureProcess.Signal(s)
+		<-untilFailureProcess.Wait()
+		return new(CancelledError)
+	}
+}
+
+// if err := dec.Decode(&val); err != nil {
+//     if serr, ok := err.(*json.SyntaxError); ok {
+//         line, col := findLine(f, serr.Offset)
+//         return fmt.Errorf("%s:%d:%d: %v", f.Name(), line, col, err)
+//     }
+//     return err
+// }V

--- a/depot/steps/readiness_health_check_step_test.go
+++ b/depot/steps/readiness_health_check_step_test.go
@@ -1,0 +1,211 @@
+package steps_test
+
+import (
+	"errors"
+	"os"
+
+	"code.cloudfoundry.org/executor/depot/log_streamer/fake_log_streamer"
+	"code.cloudfoundry.org/executor/depot/steps"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/tedsuo/ifrit"
+	fake_runner "github.com/tedsuo/ifrit/fake_runner_v2"
+)
+
+var _ = Describe("NewReadinessHealthCheckStep", func() {
+	var (
+		fakeStreamer                *fake_log_streamer.FakeLogStreamer
+		untilReadyCheck             *fake_runner.TestRunner
+		untilFailureCheck           *fake_runner.TestRunner
+		process                     ifrit.Process
+		needToKillUntilFailureCheck bool
+		needToKillUntilReadyCheck   bool
+
+		step ifrit.Runner
+	)
+	BeforeEach(func() {
+		fakeStreamer = newFakeStreamer()
+		untilReadyCheck = fake_runner.NewTestRunner()
+		untilFailureCheck = fake_runner.NewTestRunner()
+		needToKillUntilFailureCheck = true
+		needToKillUntilReadyCheck = true
+	})
+
+	JustBeforeEach(func() {
+		step = steps.NewReadinessHealthCheckStep(untilReadyCheck, untilFailureCheck, fakeStreamer)
+		process = ifrit.Background(step)
+	})
+
+	AfterEach(func() {
+		if needToKillUntilReadyCheck == true {
+			Eventually(untilReadyCheck.RunCallCount).Should(Equal(1))
+			untilReadyCheck.TriggerExit(errors.New("booom!"))
+		}
+		untilReadyCheck.EnsureExit()
+
+		if needToKillUntilFailureCheck == true {
+			Eventually(untilFailureCheck.RunCallCount).Should(Equal(1))
+			untilFailureCheck.TriggerExit(errors.New("booom!"))
+		}
+		untilFailureCheck.EnsureExit()
+	})
+
+	Describe("Run", func() {
+		BeforeEach(func() {
+			needToKillUntilReadyCheck = true
+			needToKillUntilFailureCheck = false
+		})
+
+		It("emits a message to the applications log stream", func() {
+			Eventually(fakeStreamer.Stdout().(*gbytes.Buffer)).Should(
+				gbytes.Say("Starting readiness health monitoring of container\n"),
+			)
+		})
+
+		It("Runs the untilReady check", func() {
+			Eventually(untilReadyCheck.RunCallCount).Should(Equal(1))
+		})
+
+		Context("the untilReady check succeeds", func() {
+			BeforeEach(func() {
+				needToKillUntilReadyCheck = false
+				needToKillUntilFailureCheck = true
+			})
+
+			JustBeforeEach(func() {
+				Consistently(fakeStreamer.Stdout().(*gbytes.Buffer)).ShouldNot(
+					gbytes.Say("App is ready!\n"),
+				)
+
+				untilReadyCheck.TriggerExit(nil)
+			})
+
+			It("emits a message to the application log stream", func() {
+				Eventually(fakeStreamer.Stdout().(*gbytes.Buffer)).Should(
+					gbytes.Say("App is ready!\n"),
+				)
+			})
+
+			It("becomes ready", func() {
+				Eventually(process.Ready()).Should(BeClosed())
+			})
+
+			It("runs the untilFailure check", func() {
+				Eventually(untilFailureCheck.RunCallCount).Should(Equal(1))
+			})
+
+			Context("when the untilFailure check exits with an error", func() {
+				JustBeforeEach(func() {
+					Eventually(untilFailureCheck.RunCallCount).Should(Equal(1))
+					untilFailureCheck.TriggerExit(nil)
+					needToKillUntilFailureCheck = false
+					needToKillUntilReadyCheck = false
+				})
+
+				It("emits a message to the application log stream", func() {
+					Eventually(fakeStreamer.Stdout().(*gbytes.Buffer)).Should(
+						gbytes.Say("Oh no! The app is not ready anymore\n"),
+					)
+				})
+			})
+
+			Context("when the untilFailure check fails to run", func() {
+				var disaster error
+				BeforeEach(func() {
+					needToKillUntilFailureCheck = false
+					needToKillUntilReadyCheck = false
+				})
+
+				JustBeforeEach(func() {
+					disaster = errors.New("booom!")
+					untilFailureCheck.TriggerExit(disaster)
+				})
+
+				It("the step exits with an error", func() {
+					var err error
+					Eventually(process.Wait()).Should(Receive(&err))
+					Expect(err).To(MatchError(ContainSubstring("booom!")))
+				})
+
+				It("emits a message to the application log stream", func() {
+					Eventually(fakeStreamer.Stdout().(*gbytes.Buffer)).Should(
+						gbytes.Say("Failed to run the untilFailure check\n"),
+					)
+				})
+			})
+		})
+
+		Context("the untilReady check fails to run", func() {
+			var disaster error
+			BeforeEach(func() {
+				needToKillUntilFailureCheck = false
+				needToKillUntilReadyCheck = false
+			})
+
+			JustBeforeEach(func() {
+				disaster = errors.New("booom!")
+				untilReadyCheck.TriggerExit(disaster)
+			})
+
+			It("the step exits with an error", func() {
+				var err error
+				Eventually(process.Wait()).Should(Receive(&err))
+				Expect(err).To(MatchError(ContainSubstring("booom!")))
+			})
+
+			It("does not run the untilFailure check", func() {
+				Consistently(untilFailureCheck.RunCallCount).Should(Equal(0))
+			})
+
+			It("emits a message to the application log stream", func() {
+				Eventually(fakeStreamer.Stdout().(*gbytes.Buffer)).Should(
+					gbytes.Say("Failed to run the untilReady check\n"),
+				)
+			})
+
+			It("does not become ready", func() {
+				Consistently(process.Ready()).ShouldNot(BeClosed())
+			})
+		})
+	})
+
+	Describe("Signalling", func() {
+		BeforeEach(func() {
+			needToKillUntilReadyCheck = false
+			needToKillUntilFailureCheck = false
+		})
+
+		Context("while doing untilReady check", func() {
+			JustBeforeEach(func() {
+				Eventually(untilReadyCheck.RunCallCount).Should(Equal(1))
+				process.Signal(os.Interrupt)
+				Eventually(untilReadyCheck.WaitForCall()).Should(Receive(Equal(os.Interrupt)))
+				untilReadyCheck.TriggerExit(nil)
+			})
+
+			It("cancels the in-flight check", func() {
+				Eventually(process.Wait()).Should(Receive(Equal(new(steps.CancelledError))))
+			})
+
+			It("does not run the untilFailure check", func() {
+				Consistently(untilFailureCheck.RunCallCount).Should(Equal(0))
+			})
+		})
+
+		Context("while doing the  check", func() {
+			JustBeforeEach(func() {
+				untilReadyCheck.TriggerExit(nil)
+				Eventually(untilFailureCheck.RunCallCount).Should(Equal(1))
+			})
+
+			It("cancels the in-flight check", func() {
+				process.Signal(os.Interrupt)
+				Eventually(untilFailureCheck.WaitForCall()).Should(Receive(Equal(os.Interrupt)))
+				untilFailureCheck.TriggerExit(nil)
+				Eventually(process.Wait()).Should(Receive(Equal(new(steps.CancelledError))))
+			})
+		})
+	})
+})

--- a/depot/steps/readiness_health_check_step_test.go
+++ b/depot/steps/readiness_health_check_step_test.go
@@ -22,7 +22,7 @@ var _ = Describe("NewReadinessHealthCheckStep", func() {
 		process                     ifrit.Process
 		needToKillUntilFailureCheck bool
 		needToKillUntilReadyCheck   bool
-		readinessChan               chan int
+		readinessChan               chan steps.ReadinessState
 
 		step ifrit.Runner
 	)
@@ -33,7 +33,7 @@ var _ = Describe("NewReadinessHealthCheckStep", func() {
 		untilFailureCheck = fake_runner.NewTestRunner()
 		needToKillUntilFailureCheck = true
 		needToKillUntilReadyCheck = true
-		readinessChan = make(chan int, 2)
+		readinessChan = make(chan steps.ReadinessState, 2)
 	})
 
 	JustBeforeEach(func() {
@@ -105,8 +105,7 @@ var _ = Describe("NewReadinessHealthCheckStep", func() {
 			})
 
 			It("writes ready to the readiness channel", func() {
-				Eventually(readinessChan).Should(Receive(Equal(1)))
-
+				Eventually(readinessChan).Should(Receive(Equal(steps.IsReady)))
 			})
 
 			Context("when the untilFailure check exits with an error", func() {
@@ -124,7 +123,7 @@ var _ = Describe("NewReadinessHealthCheckStep", func() {
 				})
 
 				It("writes notReady to the readiness channel", func() {
-					Eventually(readinessChan).Should(Receive(Equal(2)))
+					Eventually(readinessChan).Should(Receive(Equal(steps.IsNotReady)))
 				})
 
 				XIt("the step exits with nil", func() {

--- a/depot/transformer/faketransformer/fake_transformer.go
+++ b/depot/transformer/faketransformer/fake_transformer.go
@@ -14,50 +14,50 @@ import (
 )
 
 type FakeTransformer struct {
-	StepsRunnerStub        func(lager.Logger, executor.Container, garden.Container, chan steps.ReadinessState, log_streamer.LogStreamer, transformer.Config) (ifrit.Runner, error)
+	StepsRunnerStub        func(lager.Logger, executor.Container, garden.Container, log_streamer.LogStreamer, transformer.Config) (ifrit.Runner, chan steps.ReadinessState, error)
 	stepsRunnerMutex       sync.RWMutex
 	stepsRunnerArgsForCall []struct {
 		arg1 lager.Logger
 		arg2 executor.Container
 		arg3 garden.Container
-		arg4 chan steps.ReadinessState
-		arg5 log_streamer.LogStreamer
-		arg6 transformer.Config
+		arg4 log_streamer.LogStreamer
+		arg5 transformer.Config
 	}
 	stepsRunnerReturns struct {
 		result1 ifrit.Runner
-		result2 error
+		result2 chan steps.ReadinessState
+		result3 error
 	}
 	stepsRunnerReturnsOnCall map[int]struct {
 		result1 ifrit.Runner
-		result2 error
+		result2 chan steps.ReadinessState
+		result3 error
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeTransformer) StepsRunner(arg1 lager.Logger, arg2 executor.Container, arg3 garden.Container, arg4 chan steps.ReadinessState, arg5 log_streamer.LogStreamer, arg6 transformer.Config) (ifrit.Runner, error) {
+func (fake *FakeTransformer) StepsRunner(arg1 lager.Logger, arg2 executor.Container, arg3 garden.Container, arg4 log_streamer.LogStreamer, arg5 transformer.Config) (ifrit.Runner, chan steps.ReadinessState, error) {
 	fake.stepsRunnerMutex.Lock()
 	ret, specificReturn := fake.stepsRunnerReturnsOnCall[len(fake.stepsRunnerArgsForCall)]
 	fake.stepsRunnerArgsForCall = append(fake.stepsRunnerArgsForCall, struct {
 		arg1 lager.Logger
 		arg2 executor.Container
 		arg3 garden.Container
-		arg4 chan steps.ReadinessState
-		arg5 log_streamer.LogStreamer
-		arg6 transformer.Config
-	}{arg1, arg2, arg3, arg4, arg5, arg6})
+		arg4 log_streamer.LogStreamer
+		arg5 transformer.Config
+	}{arg1, arg2, arg3, arg4, arg5})
 	stub := fake.StepsRunnerStub
 	fakeReturns := fake.stepsRunnerReturns
-	fake.recordInvocation("StepsRunner", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6})
+	fake.recordInvocation("StepsRunner", []interface{}{arg1, arg2, arg3, arg4, arg5})
 	fake.stepsRunnerMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4, arg5, arg6)
+		return stub(arg1, arg2, arg3, arg4, arg5)
 	}
 	if specificReturn {
-		return ret.result1, ret.result2
+		return ret.result1, ret.result2, ret.result3
 	}
-	return fakeReturns.result1, fakeReturns.result2
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
 func (fake *FakeTransformer) StepsRunnerCallCount() int {
@@ -66,43 +66,46 @@ func (fake *FakeTransformer) StepsRunnerCallCount() int {
 	return len(fake.stepsRunnerArgsForCall)
 }
 
-func (fake *FakeTransformer) StepsRunnerCalls(stub func(lager.Logger, executor.Container, garden.Container, chan steps.ReadinessState, log_streamer.LogStreamer, transformer.Config) (ifrit.Runner, error)) {
+func (fake *FakeTransformer) StepsRunnerCalls(stub func(lager.Logger, executor.Container, garden.Container, log_streamer.LogStreamer, transformer.Config) (ifrit.Runner, chan steps.ReadinessState, error)) {
 	fake.stepsRunnerMutex.Lock()
 	defer fake.stepsRunnerMutex.Unlock()
 	fake.StepsRunnerStub = stub
 }
 
-func (fake *FakeTransformer) StepsRunnerArgsForCall(i int) (lager.Logger, executor.Container, garden.Container, chan steps.ReadinessState, log_streamer.LogStreamer, transformer.Config) {
+func (fake *FakeTransformer) StepsRunnerArgsForCall(i int) (lager.Logger, executor.Container, garden.Container, log_streamer.LogStreamer, transformer.Config) {
 	fake.stepsRunnerMutex.RLock()
 	defer fake.stepsRunnerMutex.RUnlock()
 	argsForCall := fake.stepsRunnerArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
 }
 
-func (fake *FakeTransformer) StepsRunnerReturns(result1 ifrit.Runner, result2 error) {
+func (fake *FakeTransformer) StepsRunnerReturns(result1 ifrit.Runner, result2 chan steps.ReadinessState, result3 error) {
 	fake.stepsRunnerMutex.Lock()
 	defer fake.stepsRunnerMutex.Unlock()
 	fake.StepsRunnerStub = nil
 	fake.stepsRunnerReturns = struct {
 		result1 ifrit.Runner
-		result2 error
-	}{result1, result2}
+		result2 chan steps.ReadinessState
+		result3 error
+	}{result1, result2, result3}
 }
 
-func (fake *FakeTransformer) StepsRunnerReturnsOnCall(i int, result1 ifrit.Runner, result2 error) {
+func (fake *FakeTransformer) StepsRunnerReturnsOnCall(i int, result1 ifrit.Runner, result2 chan steps.ReadinessState, result3 error) {
 	fake.stepsRunnerMutex.Lock()
 	defer fake.stepsRunnerMutex.Unlock()
 	fake.StepsRunnerStub = nil
 	if fake.stepsRunnerReturnsOnCall == nil {
 		fake.stepsRunnerReturnsOnCall = make(map[int]struct {
 			result1 ifrit.Runner
-			result2 error
+			result2 chan steps.ReadinessState
+			result3 error
 		})
 	}
 	fake.stepsRunnerReturnsOnCall[i] = struct {
 		result1 ifrit.Runner
-		result2 error
-	}{result1, result2}
+		result2 chan steps.ReadinessState
+		result3 error
+	}{result1, result2, result3}
 }
 
 func (fake *FakeTransformer) Invocations() map[string][][]interface{} {

--- a/depot/transformer/faketransformer/fake_transformer.go
+++ b/depot/transformer/faketransformer/fake_transformer.go
@@ -6,6 +6,7 @@ import (
 
 	"code.cloudfoundry.org/executor"
 	"code.cloudfoundry.org/executor/depot/log_streamer"
+	"code.cloudfoundry.org/executor/depot/steps"
 	"code.cloudfoundry.org/executor/depot/transformer"
 	"code.cloudfoundry.org/garden"
 	lager "code.cloudfoundry.org/lager/v3"
@@ -13,14 +14,15 @@ import (
 )
 
 type FakeTransformer struct {
-	StepsRunnerStub        func(lager.Logger, executor.Container, garden.Container, log_streamer.LogStreamer, transformer.Config) (ifrit.Runner, error)
+	StepsRunnerStub        func(lager.Logger, executor.Container, garden.Container, chan steps.ReadinessState, log_streamer.LogStreamer, transformer.Config) (ifrit.Runner, error)
 	stepsRunnerMutex       sync.RWMutex
 	stepsRunnerArgsForCall []struct {
 		arg1 lager.Logger
 		arg2 executor.Container
 		arg3 garden.Container
-		arg4 log_streamer.LogStreamer
-		arg5 transformer.Config
+		arg4 chan steps.ReadinessState
+		arg5 log_streamer.LogStreamer
+		arg6 transformer.Config
 	}
 	stepsRunnerReturns struct {
 		result1 ifrit.Runner
@@ -34,22 +36,23 @@ type FakeTransformer struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeTransformer) StepsRunner(arg1 lager.Logger, arg2 executor.Container, arg3 garden.Container, arg4 log_streamer.LogStreamer, arg5 transformer.Config) (ifrit.Runner, error) {
+func (fake *FakeTransformer) StepsRunner(arg1 lager.Logger, arg2 executor.Container, arg3 garden.Container, arg4 chan steps.ReadinessState, arg5 log_streamer.LogStreamer, arg6 transformer.Config) (ifrit.Runner, error) {
 	fake.stepsRunnerMutex.Lock()
 	ret, specificReturn := fake.stepsRunnerReturnsOnCall[len(fake.stepsRunnerArgsForCall)]
 	fake.stepsRunnerArgsForCall = append(fake.stepsRunnerArgsForCall, struct {
 		arg1 lager.Logger
 		arg2 executor.Container
 		arg3 garden.Container
-		arg4 log_streamer.LogStreamer
-		arg5 transformer.Config
-	}{arg1, arg2, arg3, arg4, arg5})
+		arg4 chan steps.ReadinessState
+		arg5 log_streamer.LogStreamer
+		arg6 transformer.Config
+	}{arg1, arg2, arg3, arg4, arg5, arg6})
 	stub := fake.StepsRunnerStub
 	fakeReturns := fake.stepsRunnerReturns
-	fake.recordInvocation("StepsRunner", []interface{}{arg1, arg2, arg3, arg4, arg5})
+	fake.recordInvocation("StepsRunner", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6})
 	fake.stepsRunnerMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4, arg5)
+		return stub(arg1, arg2, arg3, arg4, arg5, arg6)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -63,17 +66,17 @@ func (fake *FakeTransformer) StepsRunnerCallCount() int {
 	return len(fake.stepsRunnerArgsForCall)
 }
 
-func (fake *FakeTransformer) StepsRunnerCalls(stub func(lager.Logger, executor.Container, garden.Container, log_streamer.LogStreamer, transformer.Config) (ifrit.Runner, error)) {
+func (fake *FakeTransformer) StepsRunnerCalls(stub func(lager.Logger, executor.Container, garden.Container, chan steps.ReadinessState, log_streamer.LogStreamer, transformer.Config) (ifrit.Runner, error)) {
 	fake.stepsRunnerMutex.Lock()
 	defer fake.stepsRunnerMutex.Unlock()
 	fake.StepsRunnerStub = stub
 }
 
-func (fake *FakeTransformer) StepsRunnerArgsForCall(i int) (lager.Logger, executor.Container, garden.Container, log_streamer.LogStreamer, transformer.Config) {
+func (fake *FakeTransformer) StepsRunnerArgsForCall(i int) (lager.Logger, executor.Container, garden.Container, chan steps.ReadinessState, log_streamer.LogStreamer, transformer.Config) {
 	fake.stepsRunnerMutex.RLock()
 	defer fake.stepsRunnerMutex.RUnlock()
 	argsForCall := fake.stepsRunnerArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6
 }
 
 func (fake *FakeTransformer) StepsRunnerReturns(result1 ifrit.Runner, result2 error) {

--- a/depot/transformer/transformer.go
+++ b/depot/transformer/transformer.go
@@ -672,7 +672,7 @@ func (t *transformer) transformReadinessCheckDefinition(
 		return nil, nil, err
 	}
 
-	readinessChan := make(chan steps.ReadinessState, 10)
+	readinessChan := make(chan steps.ReadinessState)
 
 	if check.HttpCheck != nil {
 		timeout, interval, path := t.applyCheckDefaults(

--- a/depot/transformer/transformer.go
+++ b/depot/transformer/transformer.go
@@ -749,6 +749,7 @@ func (t *transformer) transformReadinessCheckDefinition(
 		untilFailureReadinessCheck,
 		logstreamer,
 		readinessChan,
+		logger,
 	)
 }
 

--- a/depot/transformer/transformer.go
+++ b/depot/transformer/transformer.go
@@ -49,7 +49,7 @@ var HealthCheckDstPath string = filepath.Join(string(os.PathSeparator), "etc", "
 //go:generate counterfeiter -o faketransformer/fake_transformer.go . Transformer
 
 type Transformer interface {
-	StepsRunner(lager.Logger, executor.Container, garden.Container, log_streamer.LogStreamer, Config) (ifrit.Runner, error)
+	StepsRunner(lager.Logger, executor.Container, garden.Container, chan steps.ReadinessState, log_streamer.LogStreamer, Config) (ifrit.Runner, error)
 }
 
 type Config struct {
@@ -373,6 +373,7 @@ func (t *transformer) StepsRunner(
 	logger lager.Logger,
 	container executor.Container,
 	gardenContainer garden.Container,
+	readinessChan chan steps.ReadinessState,
 	logStreamer log_streamer.LogStreamer,
 	config Config,
 ) (ifrit.Runner, error) {
@@ -490,6 +491,7 @@ func (t *transformer) StepsRunner(
 			readinessMonitor = t.transformReadinessCheckDefinition(logger,
 				&container,
 				gardenContainer,
+				readinessChan,
 				logStreamer,
 				config.BindMounts,
 				proxyStartupChecks,
@@ -643,6 +645,7 @@ func (t *transformer) transformReadinessCheckDefinition(
 	logger lager.Logger,
 	container *executor.Container,
 	gardenContainer garden.Container,
+	readinessChan chan steps.ReadinessState,
 	logstreamer log_streamer.LogStreamer,
 	bindMounts []garden.BindMount,
 	proxyStartupChecks []ifrit.Runner,
@@ -744,6 +747,7 @@ func (t *transformer) transformReadinessCheckDefinition(
 		untilSuccessReadinessCheck,
 		untilFailureReadinessCheck,
 		logstreamer,
+		readinessChan,
 	)
 }
 

--- a/resources.go
+++ b/resources.go
@@ -360,7 +360,6 @@ const (
 	EventTypeContainerComplete EventType = "container_complete"
 	EventTypeContainerRunning  EventType = "container_running"
 	EventTypeContainerReserved EventType = "container_reserved"
-	EventTypeContainerNotReady EventType = "container_not_ready"
 )
 
 type LifecycleEvent interface {
@@ -380,17 +379,6 @@ func NewContainerCompleteEvent(container Container, traceID string) ContainerCom
 		traceID:      traceID,
 	}
 }
-
-type ContainerNotReadyEvent struct {
-	RawContainer Container `json:"container"`
-}
-
-func NewContainerNotReadyEvent(container Container) ContainerNotReadyEvent {
-	return ContainerNotReadyEvent{
-		RawContainer: container,
-	}
-}
-func (ContainerNotReadyEvent) EventType() EventType { return EventTypeContainerNotReady }
 
 func (ContainerCompleteEvent) EventType() EventType   { return EventTypeContainerComplete }
 func (e ContainerCompleteEvent) TraceID() string      { return e.traceID }

--- a/resources.go
+++ b/resources.go
@@ -26,6 +26,13 @@ const (
 	StateCompleted    State = "completed"
 )
 
+type Condition int
+
+const (
+	ConditionNotReady = iota
+	ConditionReady    = 1
+)
+
 const (
 	HealthcheckTag      = "executor-healthcheck"
 	HealthcheckTagValue = "executor-healthcheck"
@@ -42,6 +49,7 @@ type Container struct {
 	RunInfo
 	Tags                                  Tags
 	State                                 State              `json:"state"`
+	Condition                             Condition          `json:"condition"`
 	AllocatedAt                           int64              `json:"allocated_at"`
 	ExternalIP                            string             `json:"external_ip"`
 	InternalIP                            string             `json:"internal_ip"`
@@ -359,6 +367,7 @@ const (
 	EventTypeContainerComplete EventType = "container_complete"
 	EventTypeContainerRunning  EventType = "container_running"
 	EventTypeContainerReserved EventType = "container_reserved"
+	EventTypeContainerNotReady EventType = "container_not_ready"
 )
 
 type LifecycleEvent interface {
@@ -378,6 +387,17 @@ func NewContainerCompleteEvent(container Container, traceID string) ContainerCom
 		traceID:      traceID,
 	}
 }
+
+type ContainerNotReadyEvent struct {
+	RawContainer Container `json:"container"`
+}
+
+func NewContainerNotReadyEvent(container Container) ContainerNotReadyEvent {
+	return ContainerNotReadyEvent{
+		RawContainer: container,
+	}
+}
+func (ContainerNotReadyEvent) EventType() EventType { return EventTypeContainerNotReady }
 
 func (ContainerCompleteEvent) EventType() EventType   { return EventTypeContainerComplete }
 func (e ContainerCompleteEvent) TraceID() string      { return e.traceID }

--- a/resources.go
+++ b/resources.go
@@ -26,13 +26,6 @@ const (
 	StateCompleted    State = "completed"
 )
 
-type Condition int
-
-const (
-	ConditionNotReady = iota
-	ConditionReady    = 1
-)
-
 const (
 	HealthcheckTag      = "executor-healthcheck"
 	HealthcheckTagValue = "executor-healthcheck"
@@ -49,7 +42,7 @@ type Container struct {
 	RunInfo
 	Tags                                  Tags
 	State                                 State              `json:"state"`
-	Condition                             Condition          `json:"condition"`
+	Routable                              bool               `json:"routable"`
 	AllocatedAt                           int64              `json:"allocated_at"`
 	ExternalIP                            string             `json:"external_ip"`
 	InternalIP                            string             `json:"internal_ip"`


### PR DESCRIPTION
### What is this change about?

When LRP has readiness health checks defined executor will spun up readiness health check step inside of container.

### What problem it is trying to solve?

Currently when liveness health check fails the whole application instance is marked as crashed. Readiness health checks will keep AI running and in case of failure it won't be able to serve http requests. This is useful when AI cannot serve requests temporarily, but restarting an AI might be too expensive since many application might need time to startup, warm up cache, etc

### How should this change be described in diego-release release notes?

> Support readiness health checks

### Please provide any contextual information.

[RFC](https://github.com/cloudfoundry/community/pull/630)

Thank you!
