### PR TITLE
send container network traffic metrics via logging client

### DIFF
--- a/containermetrics/cached_container_metric.go
+++ b/containermetrics/cached_container_metric.go
@@ -7,4 +7,6 @@ type CachedContainerMetrics struct {
 	DiskQuotaBytes   uint64  `json:"disk_quota_bytes"`
 	MemoryUsageBytes uint64  `json:"memory_usage_bytes"`
 	MemoryQuotaBytes uint64  `json:"memory_quota_bytes"`
+	RxBytes          uint64  `json:"rx_bytes"`
+	TxBytes          uint64  `json:"tx_bytes"`
 }

--- a/containermetrics/reporters_runner_test.go
+++ b/containermetrics/reporters_runner_test.go
@@ -150,6 +150,8 @@ var _ = Describe("ReportersRunner", func() {
 						DiskLimitInBytes:                    megsToBytes(1024),
 						ContainerAgeInNanoseconds:           1000,
 						AbsoluteCPUEntitlementInNanoseconds: 2000,
+						RxInBytes:                           1,
+						TxInBytes:                           1,
 					},
 				},
 				"container-guid-without-index": executor.Metrics{
@@ -162,6 +164,8 @@ var _ = Describe("ReportersRunner", func() {
 						DiskLimitInBytes:                    megsToBytes(1024),
 						ContainerAgeInNanoseconds:           1001,
 						AbsoluteCPUEntitlementInNanoseconds: 2001,
+						RxInBytes:                           1,
+						TxInBytes:                           1,
 					},
 				},
 				"container-guid-with-index": executor.Metrics{
@@ -174,6 +178,8 @@ var _ = Describe("ReportersRunner", func() {
 						DiskLimitInBytes:                    megsToBytes(2048),
 						ContainerAgeInNanoseconds:           1002,
 						AbsoluteCPUEntitlementInNanoseconds: 2002,
+						RxInBytes:                           1,
+						TxInBytes:                           1,
 					},
 				},
 				"container-guid-without-preloaded-rootfs": executor.Metrics{
@@ -186,6 +192,8 @@ var _ = Describe("ReportersRunner", func() {
 						DiskLimitInBytes:                    megsToBytes(2048),
 						ContainerAgeInNanoseconds:           1003,
 						AbsoluteCPUEntitlementInNanoseconds: 2003,
+						RxInBytes:                           1,
+						TxInBytes:                           1,
 					},
 				},
 				"container-guid-without-age": executor.Metrics{
@@ -198,6 +206,8 @@ var _ = Describe("ReportersRunner", func() {
 						DiskLimitInBytes:                    megsToBytes(1024),
 						ContainerAgeInNanoseconds:           0,
 						AbsoluteCPUEntitlementInNanoseconds: 2004,
+						RxInBytes:                           1,
+						TxInBytes:                           1,
 					},
 				},
 			}
@@ -213,6 +223,8 @@ var _ = Describe("ReportersRunner", func() {
 						DiskLimitInBytes:                    megsToBytes(1024),
 						ContainerAgeInNanoseconds:           1000 + uint64(10*time.Second),
 						AbsoluteCPUEntitlementInNanoseconds: 2000,
+						RxInBytes:                           2,
+						TxInBytes:                           2,
 					},
 				},
 
@@ -226,6 +238,8 @@ var _ = Describe("ReportersRunner", func() {
 						DiskLimitInBytes:                    4096,
 						ContainerAgeInNanoseconds:           1001 + uint64(10*time.Second),
 						AbsoluteCPUEntitlementInNanoseconds: 2001,
+						RxInBytes:                           2,
+						TxInBytes:                           2,
 					},
 				},
 				"container-guid-with-index": executor.Metrics{
@@ -238,6 +252,8 @@ var _ = Describe("ReportersRunner", func() {
 						DiskLimitInBytes:                    512,
 						ContainerAgeInNanoseconds:           1002 + uint64(10*time.Second),
 						AbsoluteCPUEntitlementInNanoseconds: 2002,
+						RxInBytes:                           2,
+						TxInBytes:                           2,
 					}},
 				"container-guid-without-preloaded-rootfs": executor.Metrics{
 					MetricsConfig: executor.MetricsConfig{Tags: map[string]string{"source_id": "source-id-without-preloaded-rootfs"}},
@@ -249,6 +265,8 @@ var _ = Describe("ReportersRunner", func() {
 						DiskLimitInBytes:                    2048,
 						ContainerAgeInNanoseconds:           1003 + uint64(10*time.Second),
 						AbsoluteCPUEntitlementInNanoseconds: 2003,
+						RxInBytes:                           2,
+						TxInBytes:                           2,
 					},
 				},
 				"container-guid-without-age": executor.Metrics{
@@ -261,6 +279,8 @@ var _ = Describe("ReportersRunner", func() {
 						DiskLimitInBytes:                    megsToBytes(1024),
 						ContainerAgeInNanoseconds:           0,
 						AbsoluteCPUEntitlementInNanoseconds: 2004,
+						RxInBytes:                           2,
+						TxInBytes:                           2,
 					},
 				},
 				"container-guid-without-metrics-at-t0": executor.Metrics{
@@ -273,6 +293,8 @@ var _ = Describe("ReportersRunner", func() {
 						DiskLimitInBytes:                    512,
 						ContainerAgeInNanoseconds:           1002 + uint64(10*time.Second),
 						AbsoluteCPUEntitlementInNanoseconds: 2002,
+						RxInBytes:                           2,
+						TxInBytes:                           2,
 					},
 				},
 			}
@@ -288,6 +310,8 @@ var _ = Describe("ReportersRunner", func() {
 						DiskLimitInBytes:                    megsToBytes(1024),
 						ContainerAgeInNanoseconds:           1000 + uint64(20*time.Second),
 						AbsoluteCPUEntitlementInNanoseconds: 2000,
+						RxInBytes:                           3,
+						TxInBytes:                           3,
 					},
 				},
 
@@ -301,6 +325,8 @@ var _ = Describe("ReportersRunner", func() {
 						DiskLimitInBytes:                    234,
 						ContainerAgeInNanoseconds:           1001 + uint64(20*time.Second),
 						AbsoluteCPUEntitlementInNanoseconds: 2001,
+						RxInBytes:                           3,
+						TxInBytes:                           3,
 					},
 				},
 				"container-guid-with-index": executor.Metrics{
@@ -313,6 +339,8 @@ var _ = Describe("ReportersRunner", func() {
 						DiskLimitInBytes:                    43200,
 						ContainerAgeInNanoseconds:           1002 + uint64(20*time.Second),
 						AbsoluteCPUEntitlementInNanoseconds: 2002,
+						RxInBytes:                           3,
+						TxInBytes:                           3,
 					},
 				},
 				"container-guid-without-preloaded-rootfs": executor.Metrics{
@@ -325,6 +353,8 @@ var _ = Describe("ReportersRunner", func() {
 						DiskLimitInBytes:                    2048,
 						ContainerAgeInNanoseconds:           1003 + uint64(20*time.Second),
 						AbsoluteCPUEntitlementInNanoseconds: 2003,
+						RxInBytes:                           3,
+						TxInBytes:                           3,
 					},
 				},
 				"container-guid-without-age": executor.Metrics{
@@ -337,6 +367,8 @@ var _ = Describe("ReportersRunner", func() {
 						DiskLimitInBytes:                    megsToBytes(1024),
 						ContainerAgeInNanoseconds:           0,
 						AbsoluteCPUEntitlementInNanoseconds: 2004,
+						RxInBytes:                           3,
+						TxInBytes:                           3,
 					},
 				},
 				"container-guid-without-metrics-at-t0": executor.Metrics{
@@ -349,6 +381,8 @@ var _ = Describe("ReportersRunner", func() {
 						DiskLimitInBytes:                    512,
 						ContainerAgeInNanoseconds:           1002 + uint64(20*time.Second),
 						AbsoluteCPUEntitlementInNanoseconds: 2002,
+						RxInBytes:                           3,
+						TxInBytes:                           3,
 					},
 				},
 			}
@@ -369,6 +403,8 @@ var _ = Describe("ReportersRunner", func() {
 					AbsoluteCPUUsage:       uint64(metricsAtT0["container-guid-without-index"].ContainerMetrics.TimeSpentInCPU),
 					AbsoluteCPUEntitlement: metricsAtT0["container-guid-without-index"].ContainerMetrics.AbsoluteCPUEntitlementInNanoseconds,
 					ContainerAge:           metricsAtT0["container-guid-without-index"].ContainerMetrics.ContainerAgeInNanoseconds,
+					RxBytes:                metricsAtT0["container-guid-without-index"].ContainerMetrics.RxInBytes,
+					TxBytes:                metricsAtT0["container-guid-without-index"].ContainerMetrics.TxInBytes,
 					Tags: map[string]string{
 						"source_id":   "source-id-without-index",
 						"instance_id": "0",
@@ -383,6 +419,8 @@ var _ = Describe("ReportersRunner", func() {
 					AbsoluteCPUUsage:       uint64(metricsAtT0["container-guid-with-index"].ContainerMetrics.TimeSpentInCPU),
 					AbsoluteCPUEntitlement: metricsAtT0["container-guid-with-index"].ContainerMetrics.AbsoluteCPUEntitlementInNanoseconds,
 					ContainerAge:           metricsAtT0["container-guid-with-index"].ContainerMetrics.ContainerAgeInNanoseconds,
+					RxBytes:                metricsAtT0["container-guid-with-index"].ContainerMetrics.RxInBytes,
+					TxBytes:                metricsAtT0["container-guid-with-index"].ContainerMetrics.TxInBytes,
 					Tags: map[string]string{
 						"source_id":   "source-id-with-index",
 						"instance_id": "1",
@@ -397,6 +435,8 @@ var _ = Describe("ReportersRunner", func() {
 					AbsoluteCPUUsage:       uint64(metricsAtT0["container-guid-without-preloaded-rootfs"].ContainerMetrics.TimeSpentInCPU),
 					AbsoluteCPUEntitlement: metricsAtT0["container-guid-without-preloaded-rootfs"].ContainerMetrics.AbsoluteCPUEntitlementInNanoseconds,
 					ContainerAge:           metricsAtT0["container-guid-without-preloaded-rootfs"].ContainerMetrics.ContainerAgeInNanoseconds,
+					RxBytes:                metricsAtT0["container-guid-without-preloaded-rootfs"].ContainerMetrics.RxInBytes,
+					TxBytes:                metricsAtT0["container-guid-without-preloaded-rootfs"].ContainerMetrics.TxInBytes,
 					Tags: map[string]string{
 						"source_id":   "source-id-without-preloaded-rootfs",
 						"instance_id": "0",
@@ -411,6 +451,8 @@ var _ = Describe("ReportersRunner", func() {
 					AbsoluteCPUUsage:       uint64(metricsAtT0["container-guid-without-age"].ContainerMetrics.TimeSpentInCPU),
 					AbsoluteCPUEntitlement: metricsAtT0["container-guid-without-age"].ContainerMetrics.AbsoluteCPUEntitlementInNanoseconds,
 					ContainerAge:           metricsAtT0["container-guid-without-age"].ContainerMetrics.ContainerAgeInNanoseconds,
+					RxBytes:                metricsAtT0["container-guid-without-age"].ContainerMetrics.RxInBytes,
+					TxBytes:                metricsAtT0["container-guid-without-age"].ContainerMetrics.TxInBytes,
 					Tags: map[string]string{
 						"source_id":   "source-id-without-age",
 						"instance_id": "0",
@@ -428,7 +470,7 @@ var _ = Describe("ReportersRunner", func() {
 			))
 		})
 
-		Context("when contianers EnableContainerProxy is set", func() {
+		Context("when containers EnableContainerProxy is set", func() {
 			BeforeEach(func() {
 				containers := []executor.Container{
 					{
@@ -473,6 +515,8 @@ var _ = Describe("ReportersRunner", func() {
 							AbsoluteCPUUsage:       uint64(metricsAtT0["container-guid-without-index"].ContainerMetrics.TimeSpentInCPU),
 							AbsoluteCPUEntitlement: metricsAtT0["container-guid-without-index"].ContainerMetrics.AbsoluteCPUEntitlementInNanoseconds,
 							ContainerAge:           metricsAtT0["container-guid-without-index"].ContainerMetrics.ContainerAgeInNanoseconds,
+							RxBytes:                metricsAtT0["container-guid-without-index"].ContainerMetrics.RxInBytes,
+							TxBytes:                metricsAtT0["container-guid-without-index"].ContainerMetrics.TxInBytes,
 							Tags: map[string]string{
 								"source_id":   "source-id-without-index",
 								"instance_id": "0",
@@ -501,6 +545,8 @@ var _ = Describe("ReportersRunner", func() {
 							AbsoluteCPUUsage:       uint64(metricsAtT0["container-guid-without-index"].ContainerMetrics.TimeSpentInCPU),
 							AbsoluteCPUEntitlement: metricsAtT0["container-guid-without-index"].ContainerMetrics.AbsoluteCPUEntitlementInNanoseconds,
 							ContainerAge:           metricsAtT0["container-guid-without-index"].ContainerMetrics.ContainerAgeInNanoseconds,
+							RxBytes:                metricsAtT0["container-guid-without-index"].ContainerMetrics.RxInBytes,
+							TxBytes:                metricsAtT0["container-guid-without-index"].ContainerMetrics.TxInBytes,
 							Tags: map[string]string{
 								"source_id":   "source-id-without-index",
 								"instance_id": "0",
@@ -521,6 +567,8 @@ var _ = Describe("ReportersRunner", func() {
 								AbsoluteCPUUsage:       uint64(metricsAtT0["container-guid-without-preloaded-rootfs"].ContainerMetrics.TimeSpentInCPU),
 								AbsoluteCPUEntitlement: metricsAtT0["container-guid-without-preloaded-rootfs"].ContainerMetrics.AbsoluteCPUEntitlementInNanoseconds,
 								ContainerAge:           metricsAtT0["container-guid-without-preloaded-rootfs"].ContainerMetrics.ContainerAgeInNanoseconds,
+								RxBytes:                metricsAtT0["container-guid-without-preloaded-rootfs"].ContainerMetrics.RxInBytes,
+								TxBytes:                metricsAtT0["container-guid-without-preloaded-rootfs"].ContainerMetrics.TxInBytes,
 								Tags: map[string]string{
 									"source_id":   "source-id-without-preloaded-rootfs",
 									"instance_id": "0",
@@ -557,6 +605,8 @@ var _ = Describe("ReportersRunner", func() {
 					AbsoluteCPUUsage:       uint64(metricsAtT10["container-guid-without-index"].ContainerMetrics.TimeSpentInCPU),
 					AbsoluteCPUEntitlement: metricsAtT10["container-guid-without-index"].ContainerMetrics.AbsoluteCPUEntitlementInNanoseconds,
 					ContainerAge:           metricsAtT10["container-guid-without-index"].ContainerMetrics.ContainerAgeInNanoseconds,
+					RxBytes:                metricsAtT10["container-guid-without-index"].ContainerMetrics.RxInBytes,
+					TxBytes:                metricsAtT10["container-guid-without-index"].ContainerMetrics.TxInBytes,
 					Tags: map[string]string{
 						"source_id":   "source-id-without-index",
 						"instance_id": "0",
@@ -572,6 +622,8 @@ var _ = Describe("ReportersRunner", func() {
 					AbsoluteCPUUsage:       uint64(metricsAtT10["container-guid-with-index"].ContainerMetrics.TimeSpentInCPU),
 					AbsoluteCPUEntitlement: metricsAtT10["container-guid-with-index"].ContainerMetrics.AbsoluteCPUEntitlementInNanoseconds,
 					ContainerAge:           metricsAtT10["container-guid-with-index"].ContainerMetrics.ContainerAgeInNanoseconds,
+					RxBytes:                metricsAtT10["container-guid-with-index"].ContainerMetrics.RxInBytes,
+					TxBytes:                metricsAtT10["container-guid-with-index"].ContainerMetrics.TxInBytes,
 					Tags: map[string]string{
 						"source_id":   "source-id-with-index",
 						"instance_id": "1",
@@ -587,6 +639,8 @@ var _ = Describe("ReportersRunner", func() {
 					AbsoluteCPUUsage:       uint64(metricsAtT10["container-guid-without-preloaded-rootfs"].ContainerMetrics.TimeSpentInCPU),
 					AbsoluteCPUEntitlement: metricsAtT10["container-guid-without-preloaded-rootfs"].ContainerMetrics.AbsoluteCPUEntitlementInNanoseconds,
 					ContainerAge:           metricsAtT10["container-guid-without-preloaded-rootfs"].ContainerMetrics.ContainerAgeInNanoseconds,
+					RxBytes:                metricsAtT10["container-guid-without-preloaded-rootfs"].ContainerMetrics.RxInBytes,
+					TxBytes:                metricsAtT10["container-guid-without-preloaded-rootfs"].ContainerMetrics.TxInBytes,
 					Tags: map[string]string{
 						"source_id":   "source-id-without-preloaded-rootfs",
 						"instance_id": "0",
@@ -602,6 +656,8 @@ var _ = Describe("ReportersRunner", func() {
 					AbsoluteCPUUsage:       uint64(metricsAtT10["container-guid-without-metrics-at-t0"].ContainerMetrics.TimeSpentInCPU),
 					AbsoluteCPUEntitlement: metricsAtT10["container-guid-without-metrics-at-t0"].ContainerMetrics.AbsoluteCPUEntitlementInNanoseconds,
 					ContainerAge:           metricsAtT10["container-guid-without-metrics-at-t0"].ContainerMetrics.ContainerAgeInNanoseconds,
+					RxBytes:                metricsAtT10["container-guid-without-metrics-at-t0"].ContainerMetrics.RxInBytes,
+					TxBytes:                metricsAtT10["container-guid-without-metrics-at-t0"].ContainerMetrics.TxInBytes,
 					Tags: map[string]string{
 						"source_id":   "source-id-without-metrics-at-t0",
 						"instance_id": "1",
@@ -620,6 +676,8 @@ var _ = Describe("ReportersRunner", func() {
 						DiskUsageBytes:   4560,
 						MemoryQuotaBytes: megsToBytes(7890),
 						DiskQuotaBytes:   4096,
+						RxBytes:          2,
+						TxBytes:          2,
 					}))
 					Expect(containerMetrics).To(HaveKeyWithValue("container-guid-with-index", &containermetrics.CachedContainerMetrics{
 						MetricGUID:       "source-id-with-index",
@@ -628,6 +686,8 @@ var _ = Describe("ReportersRunner", func() {
 						DiskUsageBytes:   6540,
 						MemoryQuotaBytes: megsToBytes(9870),
 						DiskQuotaBytes:   512,
+						RxBytes:          2,
+						TxBytes:          2,
 					}))
 					Expect(containerMetrics).To(HaveKeyWithValue("container-guid-without-source-id", &containermetrics.CachedContainerMetrics{
 						MetricGUID:       "",
@@ -636,6 +696,8 @@ var _ = Describe("ReportersRunner", func() {
 						DiskUsageBytes:   megsToBytes(456),
 						MemoryQuotaBytes: megsToBytes(789),
 						DiskQuotaBytes:   megsToBytes(1024),
+						RxBytes:          2,
+						TxBytes:          2,
 					}))
 					Expect(containerMetrics).To(HaveKeyWithValue("container-guid-without-preloaded-rootfs", &containermetrics.CachedContainerMetrics{
 						MetricGUID:       "source-id-without-preloaded-rootfs",
@@ -644,6 +706,8 @@ var _ = Describe("ReportersRunner", func() {
 						DiskUsageBytes:   4560,
 						MemoryQuotaBytes: megsToBytes(6780),
 						DiskQuotaBytes:   2048,
+						RxBytes:          2,
+						TxBytes:          2,
 					}))
 					Expect(containerMetrics).To(HaveKeyWithValue("container-guid-without-age", &containermetrics.CachedContainerMetrics{
 						MetricGUID:       "source-id-without-age",
@@ -652,6 +716,8 @@ var _ = Describe("ReportersRunner", func() {
 						DiskUsageBytes:   megsToBytes(456),
 						MemoryQuotaBytes: megsToBytes(789),
 						DiskQuotaBytes:   megsToBytes(1024),
+						RxBytes:          2,
+						TxBytes:          2,
 					}))
 					Expect(containerMetrics).To(HaveKeyWithValue("container-guid-without-metrics-at-t0", &containermetrics.CachedContainerMetrics{
 						MetricGUID:       "source-id-without-metrics-at-t0",
@@ -660,6 +726,8 @@ var _ = Describe("ReportersRunner", func() {
 						DiskUsageBytes:   6540,
 						MemoryQuotaBytes: megsToBytes(9870),
 						DiskQuotaBytes:   512,
+						RxBytes:          2,
+						TxBytes:          2,
 					}))
 				})
 			})
@@ -680,6 +748,8 @@ var _ = Describe("ReportersRunner", func() {
 						AbsoluteCPUUsage:       uint64(metricsAtT20["container-guid-without-index"].ContainerMetrics.TimeSpentInCPU),
 						AbsoluteCPUEntitlement: metricsAtT20["container-guid-without-index"].ContainerMetrics.AbsoluteCPUEntitlementInNanoseconds,
 						ContainerAge:           metricsAtT20["container-guid-without-index"].ContainerMetrics.ContainerAgeInNanoseconds,
+						RxBytes:                metricsAtT20["container-guid-without-index"].ContainerMetrics.RxInBytes,
+						TxBytes:                metricsAtT20["container-guid-without-index"].ContainerMetrics.TxInBytes,
 						Tags: map[string]string{
 							"source_id":   "source-id-without-index",
 							"instance_id": "0",
@@ -695,6 +765,8 @@ var _ = Describe("ReportersRunner", func() {
 						AbsoluteCPUUsage:       uint64(metricsAtT20["container-guid-with-index"].ContainerMetrics.TimeSpentInCPU),
 						AbsoluteCPUEntitlement: metricsAtT20["container-guid-with-index"].ContainerMetrics.AbsoluteCPUEntitlementInNanoseconds,
 						ContainerAge:           metricsAtT20["container-guid-with-index"].ContainerMetrics.ContainerAgeInNanoseconds,
+						RxBytes:                metricsAtT20["container-guid-with-index"].ContainerMetrics.RxInBytes,
+						TxBytes:                metricsAtT20["container-guid-with-index"].ContainerMetrics.TxInBytes,
 						Tags: map[string]string{
 							"source_id":   "source-id-with-index",
 							"instance_id": "1",
@@ -710,6 +782,8 @@ var _ = Describe("ReportersRunner", func() {
 						AbsoluteCPUUsage:       uint64(metricsAtT20["container-guid-without-preloaded-rootfs"].ContainerMetrics.TimeSpentInCPU),
 						AbsoluteCPUEntitlement: metricsAtT20["container-guid-without-preloaded-rootfs"].ContainerMetrics.AbsoluteCPUEntitlementInNanoseconds,
 						ContainerAge:           metricsAtT20["container-guid-without-preloaded-rootfs"].ContainerMetrics.ContainerAgeInNanoseconds,
+						RxBytes:                metricsAtT20["container-guid-without-preloaded-rootfs"].ContainerMetrics.RxInBytes,
+						TxBytes:                metricsAtT20["container-guid-without-preloaded-rootfs"].ContainerMetrics.TxInBytes,
 						Tags: map[string]string{
 							"source_id":   "source-id-without-preloaded-rootfs",
 							"instance_id": "0",
@@ -725,6 +799,8 @@ var _ = Describe("ReportersRunner", func() {
 						AbsoluteCPUUsage:       uint64(metricsAtT20["container-guid-without-metrics-at-t0"].ContainerMetrics.TimeSpentInCPU),
 						AbsoluteCPUEntitlement: metricsAtT20["container-guid-without-metrics-at-t0"].ContainerMetrics.AbsoluteCPUEntitlementInNanoseconds,
 						ContainerAge:           metricsAtT20["container-guid-without-metrics-at-t0"].ContainerMetrics.ContainerAgeInNanoseconds,
+						RxBytes:                metricsAtT20["container-guid-without-metrics-at-t0"].ContainerMetrics.RxInBytes,
+						TxBytes:                metricsAtT20["container-guid-without-metrics-at-t0"].ContainerMetrics.TxInBytes,
 						Tags: map[string]string{
 							"source_id":   "source-id-without-metrics-at-t0",
 							"instance_id": "1",

--- a/containermetrics/stats_reporter.go
+++ b/containermetrics/stats_reporter.go
@@ -113,6 +113,8 @@ func (reporter *StatsReporter) calculateAndSendMetrics(
 			AbsoluteCPUEntitlement: containerMetrics.AbsoluteCPUEntitlementInNanoseconds,
 			ContainerAge:           containerMetrics.ContainerAgeInNanoseconds,
 			Tags:                   metricsConfig.Tags,
+			RxBytes:                containerMetrics.RxInBytes,
+			TxBytes:                containerMetrics.TxInBytes,
 		})
 
 		if err != nil {
@@ -131,6 +133,8 @@ func (reporter *StatsReporter) calculateAndSendMetrics(
 		DiskQuotaBytes:   containerMetrics.DiskLimitInBytes,
 		MemoryUsageBytes: containerMetrics.MemoryUsageInBytes,
 		MemoryQuotaBytes: containerMetrics.MemoryLimitInBytes,
+		RxBytes:          containerMetrics.RxInBytes,
+		TxBytes:          containerMetrics.TxInBytes,
 	}, &currentInfo
 }
 

--- a/depot/containerstore/containerstore.go
+++ b/depot/containerstore/containerstore.go
@@ -367,6 +367,8 @@ func (cs *containerStore) Metrics(logger lager.Logger) (map[string]executor.Cont
 			TimeSpentInCPU:                      time.Duration(gardenMetric.CPUStat.Usage),
 			ContainerAgeInNanoseconds:           uint64(gardenMetric.Age),
 			AbsoluteCPUEntitlementInNanoseconds: gardenMetric.CPUEntitlement,
+			RxInBytes:                           gardenMetric.NetworkStat.RxBytes,
+			TxInBytes:                           gardenMetric.NetworkStat.TxBytes,
 		}
 	}
 

--- a/depot/containerstore/containerstore_test.go
+++ b/depot/containerstore/containerstore_test.go
@@ -3435,7 +3435,7 @@ var _ = Describe("Container Store", func() {
 			})
 		})
 
-		Context("when listing contaipcners in garden fails", func() {
+		Context("when listing containers in garden fails", func() {
 			BeforeEach(func() {
 				gardenClient.ContainersReturns([]garden.Container{}, errors.New("failed-to-list"))
 			})

--- a/depot/containerstore/containerstore_test.go
+++ b/depot/containerstore/containerstore_test.go
@@ -3050,6 +3050,10 @@ var _ = Describe("Container Store", func() {
 						},
 						Age:            1000000000,
 						CPUEntitlement: 100,
+						NetworkStat: garden.ContainerNetworkStat{
+							RxBytes: 42,
+							TxBytes: 43,
+						},
 					},
 				},
 				containerGuid2: garden.ContainerMetricsEntry{
@@ -3065,6 +3069,10 @@ var _ = Describe("Container Store", func() {
 						},
 						Age:            2000000000,
 						CPUEntitlement: 200,
+						NetworkStat: garden.ContainerNetworkStat{
+							RxBytes: 44,
+							TxBytes: 45,
+						},
 					},
 				},
 				containerGuid4: garden.ContainerMetricsEntry{
@@ -3110,6 +3118,8 @@ var _ = Describe("Container Store", func() {
 			Expect(container1Metrics.TimeSpentInCPU).To(Equal(5 * time.Second))
 			Expect(container1Metrics.ContainerAgeInNanoseconds).To(Equal(uint64(1000000000)))
 			Expect(container1Metrics.AbsoluteCPUEntitlementInNanoseconds).To(Equal(uint64(100)))
+			Expect(container1Metrics.RxInBytes).To(Equal(uint64(42)))
+			Expect(container1Metrics.TxInBytes).To(Equal(uint64(43)))
 
 			container2Metrics, ok := metrics[containerGuid2]
 			Expect(ok).To(BeTrue())
@@ -3120,6 +3130,8 @@ var _ = Describe("Container Store", func() {
 			Expect(container2Metrics.TimeSpentInCPU).To(Equal(1 * time.Millisecond))
 			Expect(container2Metrics.ContainerAgeInNanoseconds).To(Equal(uint64(2000000000)))
 			Expect(container2Metrics.AbsoluteCPUEntitlementInNanoseconds).To(Equal(uint64(200)))
+			Expect(container2Metrics.RxInBytes).To(Equal(uint64(44)))
+			Expect(container2Metrics.TxInBytes).To(Equal(uint64(45)))
 		})
 
 		Context("when fetching bulk metrics fails", func() {
@@ -3423,7 +3435,7 @@ var _ = Describe("Container Store", func() {
 			})
 		})
 
-		Context("when listing containers in garden fails", func() {
+		Context("when listing contaipcners in garden fails", func() {
 			BeforeEach(func() {
 				gardenClient.ContainersReturns([]garden.Container{}, errors.New("failed-to-list"))
 			})

--- a/resources.go
+++ b/resources.go
@@ -234,6 +234,8 @@ type ContainerMetrics struct {
 	TimeSpentInCPU                      time.Duration `json:"time_spent_in_cpu"`
 	AbsoluteCPUEntitlementInNanoseconds uint64        `json:"absolute_cpu_entitlement_in_ns"`
 	ContainerAgeInNanoseconds           uint64        `json:"container_age_in_ns"`
+	RxInBytes                           uint64        `json:"rx_in_bytes"`
+	TxInBytes                           uint64        `json:"tx_in_bytes"`
 }
 
 type MetricsConfig struct {
@@ -385,7 +387,7 @@ func (e ContainerCompleteEvent) Container() Container { return e.RawContainer }
 func (ContainerCompleteEvent) lifecycleEvent()        {}
 
 type ContainerRunningEvent struct {
-	RawContainer Container `json:"container"`
+	RawContainer Container `json:"conptainer"`
 	traceID      string
 }
 

--- a/resources.go
+++ b/resources.go
@@ -387,7 +387,7 @@ func (e ContainerCompleteEvent) Container() Container { return e.RawContainer }
 func (ContainerCompleteEvent) lifecycleEvent()        {}
 
 type ContainerRunningEvent struct {
-	RawContainer Container `json:"conptainer"`
+	RawContainer Container `json:"container"`
 	traceID      string
 }
 


### PR DESCRIPTION
### What is this change about?
Include network traffic usage metrics in the when sending App metrics.

### What problem it is trying to solve?
Stakeholders can't observe the network traffic usage for a particular app. 

### What is the impact if the change is not made?
`cf tail -c metrics <app-guid> -f`  will not show `rx_bytes` and `tx_bytes`.

### How should this change be described in diego-release release notes?
Container network traffic is now being sent to the logging stack.

### Please provide any contextual information.
* https://cloudfoundry.slack.com/archives/C01ABMVNE9E/p1683732484532129
* https://github.com/cloudfoundry/cf-networking-release/issues/64

### Tag your pair, your PM, and/or team!
* https://github.com/JVecsei1

### Dependencies
must be merged first: 
* https://github.com/cloudfoundry/diego-logging-client/pull/82
* https://github.com/cloudfoundry/garden/pull/112