### PR TITLE
Support multiple readiness health checks

### DIFF
--- a/depot/steps/readiness_health_check_step.go
+++ b/depot/steps/readiness_health_check_step.go
@@ -58,7 +58,6 @@ func (step *readinessHealthCheckStep) Run(signals <-chan os.Signal, ready chan<-
 
 func (step *readinessHealthCheckStep) runUntilReadyProcess(signals <-chan os.Signal) error {
 	untilReadyProcess := ifrit.Background(step.untilReadyCheck)
-
 	select {
 	case err := <-untilReadyProcess.Wait():
 		if err != nil {

--- a/depot/transformer/transformer.go
+++ b/depot/transformer/transformer.go
@@ -670,7 +670,7 @@ func (t *transformer) transformReadinessCheckDefinition(
 		readinessSidecarName := fmt.Sprintf("%s-readiness-healthcheck-%d", gardenContainer.Handle(), index)
 
 		if err := check.Validate(); err != nil {
-			logger.Error("invalid-readines-check", err, lager.Data{"check": check})
+			logger.Error("invalid-readiness-check", err, lager.Data{"check": check})
 			continue
 		}
 


### PR DESCRIPTION
### What is this change about?

When LRP contains multiple readiness check definitions executor will start all of them to monitor app instance readiness. If one of them fails app instance is considered not ready. They have all to succeed for app instance to become ready.

### How should this change be described in diego-release release notes?

Support multiple readiness health checks.

### Please provide any contextual information.

[Community proposal PR](https://github.com/cloudfoundry/community/pull/630)


Thank you!
