### PR TITLE
Ensure readiness startup check and long-running check have different container names

### DIFF
--- a/depot/transformer/transformer.go
+++ b/depot/transformer/transformer.go
@@ -667,6 +667,7 @@ func (t *transformer) transformReadinessCheckDefinition(
 	readinessLogger := logger.Session("readiness-check")
 
 	for index, check := range container.CheckDefinition.ReadinessChecks {
+		untilReadySidecarName := fmt.Sprintf("%s-until-ready-healthcheck-%d", gardenContainer.Handle(), index)
 		readinessSidecarName := fmt.Sprintf("%s-readiness-healthcheck-%d", gardenContainer.Handle(), index)
 
 		if err := check.Validate(); err != nil {
@@ -686,7 +687,7 @@ func (t *transformer) transformReadinessCheckDefinition(
 				gardenContainer,
 				bindMounts,
 				path,
-				readinessSidecarName,
+				untilReadySidecarName,
 				int(check.HttpCheck.Port),
 				timeout,
 				HTTPCheck,

--- a/depot/transformer/transformer_test.go
+++ b/depot/transformer/transformer_test.go
@@ -842,7 +842,7 @@ var _ = Describe("Transformer", func() {
 									It("uses sane defaults for the untilReadyCheck", func() {
 										Eventually(gardenContainer.RunCallCount).Should(Equal(3))
 										Eventually(specs).Should(Receive(Equal(garden.ProcessSpec{
-											ID:   fmt.Sprintf("%s-%s", gardenContainer.Handle(), "readiness-healthcheck-0"),
+											ID:   fmt.Sprintf("%s-%s", gardenContainer.Handle(), "until-ready-healthcheck-0"),
 											Path: filepath.Join(transformer.HealthCheckDstPath, "healthcheck"),
 											Args: []string{
 												"-port=8989",
@@ -882,7 +882,7 @@ var _ = Describe("Transformer", func() {
 								It("runs the untilReadyCheck in a sidecar container", func() {
 									Eventually(gardenContainer.RunCallCount).Should(Equal(3))
 									Eventually(specs).Should(Receive(Equal(garden.ProcessSpec{
-										ID:   fmt.Sprintf("%s-%s", gardenContainer.Handle(), "readiness-healthcheck-0"),
+										ID:   fmt.Sprintf("%s-%s", gardenContainer.Handle(), "until-ready-healthcheck-0"),
 										Path: filepath.Join(transformer.HealthCheckDstPath, "healthcheck"),
 										Args: []string{
 											"-port=8989",


### PR DESCRIPTION

When the names are the same, the long-running check fails on windows, because a container with the same name (startup check) is still in use (despite the process having exited).
