### PR TITLE
allow enabling/disabling generating log metrics

### DIFF
--- a/client.go
+++ b/client.go
@@ -37,14 +37,16 @@ type EventSource interface {
 }
 
 type AllocationRequest struct {
-	Guid string
+	Guid               string
+	GenerateLogMetrics bool
 	Resource
 	Tags
 }
 
-func NewAllocationRequest(guid string, resource *Resource, tags Tags) AllocationRequest {
+func NewAllocationRequest(guid string, resource *Resource, generateLogMetrics bool, tags Tags) AllocationRequest {
 	return AllocationRequest{
 		Guid:     guid,
+		GenerateLogMetrics: generateLogMetrics,
 		Resource: *resource,
 		Tags:     tags,
 	}

--- a/depot/containerstore/containerstore.go
+++ b/depot/containerstore/containerstore.go
@@ -161,6 +161,7 @@ func (cs *containerStore) Reserve(logger lager.Logger, traceID string, req *exec
 			cs.volumeManager,
 			cs.credManager,
 			cs.logManager,
+			req.GenerateLogMetrics,
 			cs.eventEmitter,
 			cs.transformer,
 			cs.trustedSystemCertificatesPath,


### PR DESCRIPTION
- In general Diego does not generate container metrics for tasks. There was no way to disable log rate metrics for tasks without this change.
- Add a bool to the AllocationRequest, save that off, and when the container is run set the metricReportInterval to zero if GenerateLogMetrics is false for that container.
- Please note that this change will need to be made in lockstep with the Rep change as the structure of the AllocationRequest has changed.

### What is this change about?

Container log rate limit metrics

### What problem it is trying to solve?

Tasks never had container metrics, and when we introduced log rate limit metrics we inadvertently introduced them to all containers, not just LRP containers. 

### What is the impact if the change is not made?
Task containers will continue to generate log rate metrics (that don't have the correct tags) and no other container metrics

### How should this change be described in diego-release release notes?

Log rate limit metrics are no longer generated for tasks

### Please provide any contextual information.


### Tag your pair, your PM, and/or team!

@rroberts2222 