### PR TITLE
Ignore EntryNotFound and AlreadyClosed errors when cleaning up cache

### DIFF
--- a/depot/containerstore/dependencymanager.go
+++ b/depot/containerstore/dependencymanager.go
@@ -151,7 +151,7 @@ func (bm *dependencyManager) ReleaseCachedDependencies(logger lager.Logger, keys
 		key := &keys[i]
 		logger.Debug("releasing-cache-key", lager.Data{"cache-key": key.CacheKey, "dir": key.Dir})
 		err := bm.cache.CloseDirectory(logger, key.CacheKey, key.Dir)
-		if err != nil {
+		if err != nil && err != cacheddownloader.AlreadyClosed && err != cacheddownloader.EntryNotFound {
 			logger.Error("failed-releasing-cache-key", err, lager.Data{"cache-key": key.CacheKey, "dir": key.Dir})
 			return err
 		}


### PR DESCRIPTION
## Please provide the following information:

### What is this change about?

After container is deleted Rep cleans up [the cache](https://github.com/cloudfoundry/executor/blob/main/depot/containerstore/storenode.go#L763) If cleaning up cache fails, we retry deleting container. If cleaning up cache fails because cache entry is not found Rep gets stuck in cleaning up containers and drain never exits. Cleaning up cache should be successful if cache entry is not found.

### How should this change be described in diego-release release notes?

Cache cleanup after container deletion does not fail if cache entry is not found.

### Please provide any contextual information.

[Original issue in slack](https://cloudfoundry.slack.com/archives/C2U7KA7M4/p1693997791135449)

### Tag your pair, your PM, and/or team!

> _It's helpful to tag someone on your team or your team alias in case we need to follow up later._

Thank you!
