### PR TITLE
Improve error handling on process start

### DIFF
--- a/depot/steps/run_step.go
+++ b/depot/steps/run_step.go
@@ -166,7 +166,7 @@ func (step *runStep) Run(signals <-chan os.Signal, ready chan<- struct{}) error 
 		if err != nil {
 			processErrorMessage := "failed-creating-process"
 			step.logger.Error(processErrorMessage, err, lager.Data{"duration": step.clock.Now().Sub(runStartTime)})
-			step.WriteToStdOut(fmt.Sprintf("%s: %s", processErrorMessage, err))
+			step.writeToStdOut(fmt.Sprintf("%s: %s", processErrorMessage, err))
 
 			return err
 		}
@@ -230,7 +230,7 @@ func (step *runStep) Run(signals <-chan os.Signal, ready chan<- struct{}) error 
 				}
 			}
 
-			step.WriteToStdOut(exitErrorMessage)
+			step.writeToStdOut(exitErrorMessage)
 
 			if killed {
 				return new(ExceededGracefulShutdownIntervalError)
@@ -350,7 +350,7 @@ func (step *runStep) networkingEnvVars() []string {
 	return envVars
 }
 
-func (step *runStep) WriteToStdOut(message string) {
+func (step *runStep) writeToStdOut(message string) {
 	if !step.model.SuppressLogOutput {
 		step.streamer.Stdout().Write([]byte(message))
 		step.streamer.Flush()

--- a/depot/steps/run_step_test.go
+++ b/depot/steps/run_step_test.go
@@ -278,6 +278,18 @@ var _ = Describe("RunAction", func() {
 
 				})
 			})
+
+			Context("when Garden Run errors out", func() {
+				BeforeEach(func() {
+					gardenClient.Connection.RunStub = func(string, garden.ProcessSpec, garden.ProcessIO) (garden.Process, error) {
+						return nil, errors.New("some-error-from-garden")
+					}
+				})
+
+				It("it receives an error from the streamer", func() {
+					Expect(fakeStreamer.Stdout()).To(gbytes.Say("failed-creating-process: some-error-from-garden"))
+				})
+			})
 		})
 
 		Context("CF_INSTANCE_* networking env vars", func() {


### PR DESCRIPTION
Related to https://github.com/cloudfoundry/diego-release/issues/892. With this improvement, if there is a failure while starting a process, lets say for example the env variable is too large, here is how the app logs will look now: 
```
 2024-01-18T00:49:08.59+0000 [API/0] OUT Added process: "web"
   2024-01-18T00:49:08.59+0000 [API/0] OUT Created app with guid 043a7ccf-8838-44ab-897e-597047e87ac3
   2024-01-18T00:49:08.61+0000 [API/0] OUT Applied manifest to app with guid 043a7ccf-8838-44ab-897e-597047e87ac3 (---
   2024-01-18T00:49:08.61+0000 [API/0] OUT applications:
   2024-01-18T00:49:08.61+0000 [API/0] OUT - name: mentos-cola
   2024-01-18T00:49:08.61+0000 [API/0] OUT disk-quota: 4G
   2024-01-18T00:49:08.61+0000 [API/0] OUT memory: 500M
   2024-01-18T00:49:08.61+0000 [API/0] OUT random-route: true
   2024-01-18T00:49:08.61+0000 [API/0] OUT buildpack: https://github.com/cloudfoundry/go-buildpack.git
   2024-01-18T00:49:08.61+0000 [API/0] OUT env: "[PRIVATE DATA HIDDEN]"
   2024-01-18T00:49:08.61+0000 [API/0] OUT )
   2024-01-18T00:49:10.88+0000 [API/0] OUT Scaling process: "web"
   2024-01-18T00:49:10.95+0000 [API/0] OUT Updated app with guid 043a7ccf-8838-44ab-897e-597047e87ac3 ({"lifecycle"=>{"data"=>{"buildpacks"=>["https://github.com/cloudfoundry/go-buildpack.git"]}}})
   2024-01-18T00:49:11.08+0000 [API/0] OUT Updated app with guid 043a7ccf-8838-44ab-897e-597047e87ac3 ({"environment_variables"=>"[PRIVATE DATA HIDDEN]"})
   2024-01-18T00:49:11.97+0000 [API/0] OUT Uploading app package for app with guid 043a7ccf-8838-44ab-897e-597047e87ac3
   2024-01-18T00:49:15.17+0000 [API/0] OUT Creating build for app with guid 043a7ccf-8838-44ab-897e-597047e87ac3
   2024-01-18T00:49:15.60+0000 [STG/0] OUT Cell fcb7c7db-8a2c-4216-95d3-a7c6500c8e9c creating container for instance b9e62f25-1be6-438a-8da3-094aa5516775
   2024-01-18T00:49:16.07+0000 [STG/0] OUT Security group rules were updated
   2024-01-18T00:49:16.12+0000 [STG/0] OUT Cell fcb7c7db-8a2c-4216-95d3-a7c6500c8e9c successfully created container for instance b9e62f25-1be6-438a-8da3-094aa5516775
   2024-01-18T00:49:16.82+0000 [STG/0] OUT Downloading app package...
   2024-01-18T00:49:16.88+0000 [STG/0] OUT Downloaded app package (1.1K)
   2024-01-18T00:49:17.02+0000 [STG/0] OUT failed-creating-process: runc exec: exit status 255: exec failed: unable to start container process: exec /tmp/lifecycle/builder: argument list too long
   2024-01-18T00:49:18.37+0000 [STG/0] OUT Cell fcb7c7db-8a2c-4216-95d3-a7c6500c8e9c stopping instance b9e62f25-1be6-438a-8da3-094aa5516775
   2024-01-18T00:49:18.37+0000 [STG/0] OUT Cell fcb7c7db-8a2c-4216-95d3-a7c6500c8e9c destroying container for instance b9e62f25-1be6-438a-8da3-094aa5516775
   2024-01-18T00:49:18.43+0000 [API/0] ERR Failed to stage build: staging failed
   2024-01-18T00:49:18.88+0000 [STG/0] OUT Cell fcb7c7db-8a2c-4216-95d3-a7c6500c8e9c successfully destroyed container for instance b9e62f25-1be6-438a-8da3-094aa5516775

```

```
failed-creating-process: runc exec: exit status 255: exec failed: unable to start container process: exec /tmp/lifecycle/builder: argument list too long
```
