### PR TITLE
Update envoy's http2 configs to not use deprecated options anymore

### DIFF
--- a/depot/containerstore/proxy_config_handler.go
+++ b/depot/containerstore/proxy_config_handler.go
@@ -462,7 +462,6 @@ func generateProxyConfig(
 					LbEndpoints: adsEndpoints,
 				}},
 			},
-			Http2ProtocolOptions: &envoy_core.Http2ProtocolOptions{},
 		})
 
 		dynamicResources := &envoy_bootstrap.Bootstrap_DynamicResources{

--- a/depot/containerstore/proxy_config_handler_test.go
+++ b/depot/containerstore/proxy_config_handler_test.go
@@ -1165,8 +1165,5 @@ func createCluster(config expectedCluster) *envoy_cluster.Cluster {
 				{MaxRequests: &wrappers.UInt32Value{Value: math.MaxUint32}},
 			}}
 	}
-	if config.http2 {
-		cluster.Http2ProtocolOptions = &envoy_core.Http2ProtocolOptions{}
-	}
 	return cluster
 }


### PR DESCRIPTION
This http2 config was only used when the experimental `containers.proxy.ads_servers` attribute was present, which does not appear to work anymore anyway as specifying it causes containers to crash on envoy startup due to other unsupported configuration.