### PR TITLE
Update go-loggregator to v9

### DIFF
--- a/depot/containerstore/containerstore_test.go
+++ b/depot/containerstore/containerstore_test.go
@@ -26,7 +26,7 @@ import (
 	"code.cloudfoundry.org/garden"
 	"code.cloudfoundry.org/garden/gardenfakes"
 	"code.cloudfoundry.org/garden/server"
-	loggregator "code.cloudfoundry.org/go-loggregator/v8"
+	loggregator "code.cloudfoundry.org/go-loggregator/v9"
 	"code.cloudfoundry.org/lager/v3"
 	"code.cloudfoundry.org/routing-info/internalroutes"
 	"code.cloudfoundry.org/volman"

--- a/depot/log_streamer/log_streamer.go
+++ b/depot/log_streamer/log_streamer.go
@@ -7,7 +7,7 @@ import (
 
 	loggingclient "code.cloudfoundry.org/diego-logging-client"
 	"code.cloudfoundry.org/executor"
-	"code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2"
+	"code.cloudfoundry.org/go-loggregator/v9/rpc/loggregator_v2"
 )
 
 const (

--- a/depot/log_streamer/stream_destination.go
+++ b/depot/log_streamer/stream_destination.go
@@ -6,7 +6,7 @@ import (
 	"unicode/utf8"
 
 	loggingclient "code.cloudfoundry.org/diego-logging-client"
-	"code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2"
+	"code.cloudfoundry.org/go-loggregator/v9/rpc/loggregator_v2"
 )
 
 type streamDestination struct {

--- a/depot/metrics/reporter.go
+++ b/depot/metrics/reporter.go
@@ -7,7 +7,7 @@ import (
 	"code.cloudfoundry.org/clock"
 	loggingclient "code.cloudfoundry.org/diego-logging-client"
 	"code.cloudfoundry.org/executor"
-	loggregator "code.cloudfoundry.org/go-loggregator/v8"
+	loggregator "code.cloudfoundry.org/go-loggregator/v9"
 	"code.cloudfoundry.org/lager/v3"
 )
 

--- a/depot/metrics/reporter_test.go
+++ b/depot/metrics/reporter_test.go
@@ -14,8 +14,8 @@ import (
 	"code.cloudfoundry.org/executor"
 	"code.cloudfoundry.org/executor/depot/metrics"
 	"code.cloudfoundry.org/executor/fakes"
-	loggregator "code.cloudfoundry.org/go-loggregator/v8"
-	"code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2"
+	loggregator "code.cloudfoundry.org/go-loggregator/v9"
+	"code.cloudfoundry.org/go-loggregator/v9/rpc/loggregator_v2"
 	"code.cloudfoundry.org/lager/v3/lagertest"
 	"github.com/tedsuo/ifrit"
 )

--- a/gardenhealth/runner_test.go
+++ b/gardenhealth/runner_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"code.cloudfoundry.org/executor/gardenhealth"
-	loggregator "code.cloudfoundry.org/go-loggregator/v8"
+	loggregator "code.cloudfoundry.org/go-loggregator/v9"
 	"github.com/tedsuo/ifrit"
 	ginkgomon "github.com/tedsuo/ifrit/ginkgomon_v2"
 

--- a/initializer/initializer_test.go
+++ b/initializer/initializer_test.go
@@ -24,7 +24,7 @@ import (
 	"code.cloudfoundry.org/executor/initializer/configuration"
 	"code.cloudfoundry.org/executor/initializer/fakes"
 	"code.cloudfoundry.org/garden"
-	loggregator "code.cloudfoundry.org/go-loggregator/v8"
+	loggregator "code.cloudfoundry.org/go-loggregator/v9"
 	"code.cloudfoundry.org/lager/v3"
 	"code.cloudfoundry.org/lager/v3/lagertest"
 	. "github.com/onsi/ginkgo/v2"


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Update go-loggregator/v8 to go-loggregator/v9

Backward Compatibility
---------------
Breaking Change? **No**