### PR TITLE
Fix staticcheck error for Errorf

### DIFF
--- a/depot/log_streamer/log_rate_limiter.go
+++ b/depot/log_streamer/log_rate_limiter.go
@@ -2,6 +2,7 @@ package log_streamer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync/atomic"
 	"time"
@@ -78,14 +79,14 @@ func (r *logRateLimiter) Limit(sourceName string, logLength int) error {
 		reportMessage := fmt.Sprintf("app instance exceeded log rate limit (%d bytes/sec)", r.maxLogBytesPerSecond)
 		r.reportOverlimit(sourceName, reportMessage)
 		r.lastOverage = time.Now()
-		return fmt.Errorf(reportMessage)
+		return errors.New(reportMessage)
 	}
 
 	if !r.maxLogLinesPerSecondLimiter.Allow() {
 		reportMessage := fmt.Sprintf("app instance exceeded log rate limit (%d log-lines/sec) set by platform operator", r.maxLogLinesPerSecond)
 		r.reportOverlimit(sourceName, reportMessage)
 		r.lastOverage = time.Now()
-		return fmt.Errorf(reportMessage)
+		return errors.New(reportMessage)
 	}
 
 	atomic.AddUint64(&r.bytesEmittedLastInterval, uint64(logLength))


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Fixing error:
```
printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
```

Backward Compatibility
---------------
Breaking Change? **No**
