### PR TITLE
Fix failing test after removing replace directive for gomega

### DIFF
--- a/depot/transformer/transformer_test.go
+++ b/depot/transformer/transformer_test.go
@@ -215,7 +215,8 @@ var _ = Describe("Transformer", func() {
 
 				process.Signal(os.Interrupt)
 				clock.Increment(1 * time.Second)
-				Eventually(process.Wait()).Should(Receive(nil))
+				var nilObject interface{}
+				Eventually(process.Wait()).Should(Receive(&nilObject))
 			})
 		})
 
@@ -346,7 +347,7 @@ var _ = Describe("Transformer", func() {
 						},
 						CheckDefinition: &models.CheckDefinition{
 							Checks: []*models.Check{
-								&models.Check{
+								{
 									HttpCheck: &models.HTTPCheck{
 										Port:             5432,
 										RequestTimeoutMs: 100,
@@ -356,11 +357,11 @@ var _ = Describe("Transformer", func() {
 							},
 						},
 						Ports: []executor.PortMapping{
-							executor.PortMapping{
+							{
 								HostPort:      61001,
 								ContainerPort: 8080,
 							},
-							executor.PortMapping{
+							{
 								HostPort:      61002,
 								ContainerPort: 61001,
 							},
@@ -726,7 +727,7 @@ var _ = Describe("Transformer", func() {
 						})
 						container.CheckDefinition = &models.CheckDefinition{
 							Checks: []*models.Check{
-								&models.Check{
+								{
 									HttpCheck: &models.HTTPCheck{
 										Port:             5432,
 										RequestTimeoutMs: 100,
@@ -947,7 +948,7 @@ var _ = Describe("Transformer", func() {
 							BeforeEach(func() {
 								container.CheckDefinition = &models.CheckDefinition{
 									ReadinessChecks: []*models.Check{
-										&models.Check{
+										{
 											TcpCheck: &models.TCPCheck{
 												Port:             5432,
 												ConnectTimeoutMs: 101,
@@ -1071,7 +1072,7 @@ var _ = Describe("Transformer", func() {
 									BeforeEach(func() {
 										container.CheckDefinition = &models.CheckDefinition{
 											ReadinessChecks: []*models.Check{
-												&models.Check{
+												{
 													TcpCheck: &models.TCPCheck{
 														Port: 5432,
 													},
@@ -1376,7 +1377,7 @@ var _ = Describe("Transformer", func() {
 						BeforeEach(func() {
 							container.CheckDefinition = &models.CheckDefinition{
 								Checks: []*models.Check{
-									&models.Check{
+									{
 										HttpCheck: &models.HTTPCheck{
 											Port: 6432,
 										},
@@ -1507,7 +1508,7 @@ var _ = Describe("Transformer", func() {
 							BeforeEach(func() {
 								container.CheckDefinition = &models.CheckDefinition{
 									Checks: []*models.Check{
-										&models.Check{
+										{
 											HttpCheck: &models.HTTPCheck{
 												Port: 6432,
 											},
@@ -1537,7 +1538,6 @@ var _ = Describe("Transformer", func() {
 									"-liveness-interval=1s",
 								}))
 							})
-
 						})
 
 						Context("when the liveness check exits", func() {
@@ -1583,7 +1583,7 @@ var _ = Describe("Transformer", func() {
 					BeforeEach(func() {
 						container.CheckDefinition = &models.CheckDefinition{
 							Checks: []*models.Check{
-								&models.Check{
+								{
 									TcpCheck: &models.TCPCheck{
 										Port:             5432,
 										ConnectTimeoutMs: 100,
@@ -1598,7 +1598,7 @@ var _ = Describe("Transformer", func() {
 						BeforeEach(func() {
 							container.CheckDefinition = &models.CheckDefinition{
 								Checks: []*models.Check{
-									&models.Check{
+									{
 										TcpCheck: &models.TCPCheck{
 											Port: 6432,
 										},
@@ -1673,14 +1673,13 @@ var _ = Describe("Transformer", func() {
 								"-timeout=100ms",
 								"-liveness-interval=44ms",
 							}))
-
 						})
 
 						Context("and optional fields are missing", func() {
 							BeforeEach(func() {
 								container.CheckDefinition = &models.CheckDefinition{
 									Checks: []*models.Check{
-										&models.Check{
+										{
 											TcpCheck: &models.TCPCheck{
 												Port: 6432,
 											},
@@ -1710,7 +1709,6 @@ var _ = Describe("Transformer", func() {
 								}))
 							})
 						})
-
 					})
 				})
 
@@ -1718,7 +1716,7 @@ var _ = Describe("Transformer", func() {
 					BeforeEach(func() {
 						container.CheckDefinition = &models.CheckDefinition{
 							Checks: []*models.Check{
-								&models.Check{
+								{
 									HttpCheck: &models.HTTPCheck{
 										Port:             5432,
 										RequestTimeoutMs: 2000,
@@ -1815,14 +1813,14 @@ var _ = Describe("Transformer", func() {
 
 						container.CheckDefinition = &models.CheckDefinition{
 							Checks: []*models.Check{
-								&models.Check{
+								{
 									TcpCheck: &models.TCPCheck{
 										Port:             2222,
 										ConnectTimeoutMs: 100,
 										IntervalMs:       50,
 									},
 								},
-								&models.Check{
+								{
 									HttpCheck: &models.HTTPCheck{
 										Port:             8080,
 										RequestTimeoutMs: 100,
@@ -2038,7 +2036,8 @@ var _ = Describe("Transformer", func() {
 
 				process.Signal(os.Interrupt)
 				clock.Increment(1 * time.Second)
-				Eventually(process.Wait()).Should(Receive(nil))
+				var nilObject interface{}
+				Eventually(process.Wait()).Should(Receive(&nilObject))
 			})
 
 			It("logs the container creation time", func() {
@@ -2083,9 +2082,7 @@ var _ = Describe("Transformer", func() {
 		})
 
 		Context("MonitorAction", func() {
-			var (
-				process ifrit.Process
-			)
+			var process ifrit.Process
 
 			JustBeforeEach(func() {
 				runner, _, err := optimusPrime.StepsRunner(logger, container, gardenContainer, logStreamer, cfg)
@@ -2114,9 +2111,7 @@ var _ = Describe("Transformer", func() {
 			})
 
 			Context("SuppressLogOutput", func() {
-				var (
-					monitorCh, actionCh chan int
-				)
+				var monitorCh, actionCh chan int
 
 				BeforeEach(func() {
 					monitorCh = make(chan int, 2)


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
This is a companion PR to https://github.com/cloudfoundry/diego-release/pull/947 fixing failing tests from removing the `replace` directive for `gomega`. The failing tests show errors with the following logs:

```
Cannot assign a value from the channel:\n    <chan error | len:1, cap:1>: 0xc00044f560\nTo:\n    <nil>: nil\nYou need to pass a pointer!
```

Backward Compatibility
---------------
Breaking Change? **No**