### PR TITLE
Add metrics for failed liveness checks

### DIFF
--- a/depot/steps/emit_check_failure_metric_step.go
+++ b/depot/steps/emit_check_failure_metric_step.go
@@ -1,0 +1,74 @@
+package steps
+
+import (
+	"fmt"
+	"os"
+
+	loggingclient "code.cloudfoundry.org/diego-logging-client"
+	"code.cloudfoundry.org/executor"
+	"github.com/tedsuo/ifrit"
+)
+
+type emitCheckFailureMetricStep struct {
+	checkStep     ifrit.Runner
+	checkProtocol executor.CheckProtocol
+	checkType     executor.HealthcheckType
+	metronClient  loggingclient.IngressClient
+}
+
+const (
+	CheckFailedCount = "ChecksFailedCount"
+)
+
+func NewEmitCheckFailureMetricStep(
+	checkStep ifrit.Runner,
+	checkProtocol executor.CheckProtocol,
+	checkType executor.HealthcheckType,
+	metronClient loggingclient.IngressClient) ifrit.Runner {
+	return &emitCheckFailureMetricStep{
+		checkStep:     checkStep,
+		checkProtocol: checkProtocol,
+		checkType:     checkType,
+		metronClient:  metronClient,
+	}
+}
+
+func (step *emitCheckFailureMetricStep) Run(signals <-chan os.Signal, ready chan<- struct{}) error {
+	if step.checkStep == nil {
+		return nil
+	}
+
+	checkProccess := ifrit.Background(step.checkStep)
+
+	done := make(chan struct{})
+	defer close(done)
+	go waitForReadiness(checkProccess, ready, done)
+
+	select {
+	case err := <-checkProccess.Wait():
+		if err != nil {
+			step.emitFailureMetric()
+		}
+		return err
+	case s := <-signals:
+		checkProccess.Signal(s)
+		return <-checkProccess.Wait()
+	}
+}
+
+func (step *emitCheckFailureMetricStep) emitFailureMetric() {
+	metricName := constructMetricName(step.checkProtocol, step.checkType)
+	go step.metronClient.IncrementCounter(metricName)
+}
+
+func constructMetricName(checkProtocol executor.CheckProtocol, checkType executor.HealthcheckType) string {
+	return fmt.Sprintf("%s%s%s", checkProtocol, checkType, CheckFailedCount)
+}
+
+func waitForReadiness(p ifrit.Process, ready chan<- struct{}, done <-chan struct{}) {
+	select {
+	case <-p.Ready():
+		close(ready)
+	case <-done:
+	}
+}

--- a/depot/steps/emit_check_failure_metric_step_test.go
+++ b/depot/steps/emit_check_failure_metric_step_test.go
@@ -1,0 +1,150 @@
+package steps_test
+
+import (
+	"errors"
+	"os"
+
+	mfakes "code.cloudfoundry.org/diego-logging-client/testhelpers"
+	"code.cloudfoundry.org/executor"
+	"code.cloudfoundry.org/executor/depot/steps"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/tedsuo/ifrit"
+	fake_runner "github.com/tedsuo/ifrit/fake_runner_v2"
+)
+
+var _ = Describe("EmitCheckFailureMetricStep", func() {
+	var (
+		subStep          *fake_runner.TestRunner
+		step             ifrit.Runner
+		fakeMetronClient *mfakes.FakeIngressClient
+		errorToReturn    error
+		checkProtocol    executor.CheckProtocol
+		checkType        executor.HealthcheckType
+	)
+
+	BeforeEach(func() {
+		checkProtocol = executor.HTTPCheck
+		checkType = executor.IsLivenessCheck
+		fakeMetronClient = new(mfakes.FakeIngressClient)
+		errorToReturn = nil
+		subStep = fake_runner.NewTestRunner()
+
+		subStep.RunStub = func(signals <-chan os.Signal, ready chan<- struct{}) error {
+			return errorToReturn
+		}
+	})
+
+	AfterEach(func() {
+		subStep.EnsureExit()
+
+	})
+
+	JustBeforeEach(func() {
+		step = steps.NewEmitCheckFailureMetricStep(subStep, checkProtocol, checkType, fakeMetronClient)
+	})
+
+	Describe("Ready", func() {
+		var (
+			fakeRunner *fake_runner.TestRunner
+		)
+
+		Context("when substep is not nil", func() {
+			BeforeEach(func() {
+				fakeRunner = fake_runner.NewTestRunner()
+				subStep = fakeRunner
+			})
+
+			It("becomes ready when the substep is ready", func() {
+				p := ifrit.Background(step)
+				Consistently(p.Ready()).ShouldNot(BeClosed())
+				fakeRunner.TriggerReady()
+				Eventually(p.Ready()).Should(BeClosed())
+			})
+		})
+	})
+
+	Describe("Running", func() {
+		var (
+			err error
+		)
+
+		JustBeforeEach(func() {
+			err = <-ifrit.Invoke(step).Wait()
+		})
+
+		Context("when the substep succeeds", func() {
+			It("should not emit any metric", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(fakeMetronClient.IncrementCounterCallCount).Should(Equal(0))
+			})
+		})
+
+		Context("when the substep fails", func() {
+			BeforeEach(func() {
+				errorToReturn = errors.New("check failed")
+			})
+
+			It("should pass the error along", func() {
+				Expect(err).To(MatchError(errorToReturn))
+			})
+
+			Context("when HealthCheckType is Liveness and CheckProtocol is HTTP", func() {
+				BeforeEach(func() {
+					checkType = executor.IsLivenessCheck
+					checkProtocol = executor.HTTPCheck
+				})
+
+				It("should emit metric for the correct health check protocol and type", func() {
+					Eventually(fakeMetronClient.IncrementCounterCallCount).Should(Equal(1))
+					name := fakeMetronClient.IncrementCounterArgsForCall(0)
+					Expect(name).To(Equal("HTTPLivenessChecksFailedCount"))
+				})
+			})
+
+			Context("when HealthCheckType is Liveness and CheckProtocol is TCP", func() {
+				BeforeEach(func() {
+					checkType = executor.IsLivenessCheck
+					checkProtocol = executor.TCPCheck
+				})
+
+				It("should emit metric for the correct health check protocol and type", func() {
+					Eventually(fakeMetronClient.IncrementCounterCallCount).Should(Equal(1))
+					name := fakeMetronClient.IncrementCounterArgsForCall(0)
+					Expect(name).To(Equal("TCPLivenessChecksFailedCount"))
+				})
+			})
+		})
+	})
+
+	Describe("Signal", func() {
+		var (
+			p        ifrit.Process
+			finished chan struct{}
+		)
+
+		BeforeEach(func() {
+			finished = make(chan struct{})
+			subStep.RunStub = func(signals <-chan os.Signal, ready chan<- struct{}) error {
+				<-signals
+				close(finished)
+				return new(steps.CancelledError)
+			}
+		})
+
+		JustBeforeEach(func() {
+			p = ifrit.Background(step)
+		})
+
+		It("should pass the signal", func() {
+			Consistently(finished).ShouldNot(BeClosed())
+			p.Signal(os.Interrupt)
+			Eventually(finished).Should(BeClosed())
+		})
+
+		It("should not emit metric when cancelled", func() {
+			p.Signal(os.Interrupt)
+			Eventually(fakeMetronClient.IncrementCounterCallCount).Should(Equal(0))
+		})
+	})
+})

--- a/depot/transformer/transformer.go
+++ b/depot/transformer/transformer.go
@@ -57,6 +57,7 @@ type transformer struct {
 
 	sidecarRootFS               string
 	useDeclarativeHealthCheck   bool
+	emitHealthCheckMetrics      bool
 	healthyMonitoringInterval   time.Duration
 	unhealthyMonitoringInterval time.Duration
 	gracefulShutdownInterval    time.Duration
@@ -96,6 +97,12 @@ func WithPostSetupHook(user string, hook []string) Option {
 	return func(t *transformer) {
 		t.postSetupUser = user
 		t.postSetupHook = hook
+	}
+}
+
+func WithDeclarativeHealthcheckFailureMetrics() Option {
+	return func(t *transformer) {
+		t.emitHealthCheckMetrics = true
 	}
 }
 
@@ -859,7 +866,7 @@ func (t *transformer) transformCheckDefinition(
 				livenessLogger,
 				"",
 				metronClient,
-				true,
+				t.emitHealthCheckMetrics,
 			))
 
 		} else if check.TcpCheck != nil {
@@ -900,7 +907,7 @@ func (t *transformer) transformCheckDefinition(
 				livenessLogger,
 				"",
 				metronClient,
-				true,
+				t.emitHealthCheckMetrics,
 			))
 		}
 	}

--- a/depot/transformer/transformer_test.go
+++ b/depot/transformer/transformer_test.go
@@ -1576,10 +1576,22 @@ var _ = Describe("Transformer", func() {
 								Eventually(process.Wait()).Should(Receive(MatchError(ContainSubstring("Instance became unhealthy: liveness check failed"))))
 							})
 
-							It("emits HTTPLivenessChecksFailedCount metric", func() {
-								Eventually(fakeMetronClient.IncrementCounterCallCount).Should(Equal(1))
-								name := fakeMetronClient.IncrementCounterArgsForCall(0)
-								Expect(name).To(Equal("HTTPLivenessChecksFailedCount"))
+							Context("and emitting liveness check failures is enabled", func() {
+								BeforeEach(func() {
+									options = append(options, transformer.WithDeclarativeHealthcheckFailureMetrics())
+								})
+
+								It("emits HTTPLivenessChecksFailedCount metric", func() {
+									Eventually(fakeMetronClient.IncrementCounterCallCount).Should(Equal(1))
+									name := fakeMetronClient.IncrementCounterArgsForCall(0)
+									Expect(name).To(Equal("HTTPLivenessChecksFailedCount"))
+								})
+							})
+
+							Context("and emitting liveness check failures is disabled", func() {
+								It("does not emit HTTPLivenessChecksFailedCount metric", func() {
+									Eventually(fakeMetronClient.IncrementCounterCallCount).Should(Equal(0))
+								})
 							})
 						})
 					})
@@ -1732,10 +1744,22 @@ var _ = Describe("Transformer", func() {
 								actionCh <- 2
 							})
 
-							It("emits TCPLivenessChecksFailedCount metric", func() {
-								Eventually(fakeMetronClient.IncrementCounterCallCount).Should(Equal(1))
-								name := fakeMetronClient.IncrementCounterArgsForCall(0)
-								Expect(name).To(Equal("TCPLivenessChecksFailedCount"))
+							Context("and emitting liveness check failures is enabled", func() {
+								BeforeEach(func() {
+									options = append(options, transformer.WithDeclarativeHealthcheckFailureMetrics())
+								})
+
+								It("emits TCPLivenessChecksFailedCount metric", func() {
+									Eventually(fakeMetronClient.IncrementCounterCallCount).Should(Equal(1))
+									name := fakeMetronClient.IncrementCounterArgsForCall(0)
+									Expect(name).To(Equal("TCPLivenessChecksFailedCount"))
+								})
+							})
+
+							Context("and emitting liveness check failures is disabled", func() {
+								It("does not emit TCPLivenessChecksFailedCount metric", func() {
+									Eventually(fakeMetronClient.IncrementCounterCallCount).Should(Equal(0))
+								})
 							})
 						})
 					})

--- a/initializer/initializer.go
+++ b/initializer/initializer.go
@@ -103,6 +103,7 @@ type ExecutorConfig struct {
 	DiskMB                                string                `json:"disk_mb,omitempty"`
 	EnableContainerProxy                  bool                  `json:"enable_container_proxy,omitempty"`
 	EnableDeclarativeHealthcheck          bool                  `json:"enable_declarative_healthcheck,omitempty"`
+	EnableHealtcheckMetrics               bool                  `json:"enable_healthcheck_metrics,omitempty"`
 	EnableUnproxiedPortMappings           bool                  `json:"enable_unproxied_port_mappings"`
 	EnvoyConfigRefreshDelay               durationjson.Duration `json:"envoy_config_refresh_delay"`
 	EnvoyConfigReloadDuration             durationjson.Duration `json:"envoy_config_reload_duration"`
@@ -248,6 +249,7 @@ func Initialize(logger lager.Logger, config ExecutorConfig, cellID, zone string,
 		postSetupHook,
 		config.PostSetupUser,
 		config.EnableDeclarativeHealthcheck,
+		config.EnableHealtcheckMetrics,
 		gardenHealthcheckRootFS,
 		config.EnableContainerProxy,
 		time.Duration(config.EnvoyDrainTimeout),
@@ -544,6 +546,7 @@ func initializeTransformer(
 	postSetupHook []string,
 	postSetupUser string,
 	useDeclarativeHealthCheck bool,
+	emitHealthCheckMetrics bool,
 	declarativeHealthcheckRootFS string,
 	enableContainerProxy bool,
 	drainWait time.Duration,
@@ -555,6 +558,10 @@ func initializeTransformer(
 
 	if useDeclarativeHealthCheck {
 		options = append(options, transformer.WithDeclarativeHealthchecks())
+	}
+
+	if emitHealthCheckMetrics {
+		options = append(options, transformer.WithDeclarativeHealthcheckFailureMetrics())
 	}
 
 	if enableContainerProxy {

--- a/resources.go
+++ b/resources.go
@@ -430,3 +430,27 @@ func truncateString(s string, length int) string {
 	last := len(s) - length/2 + len(delimeter)/2
 	return fmt.Sprintf("%s%s%s", s[:((length/2-1)-len(delimeter)/2)], delimeter, s[last:])
 }
+
+type HealthcheckType int
+
+const (
+	IsStartupCheck HealthcheckType = iota
+	IsLivenessCheck
+	IsUntilSuccessReadinessCheck
+	IsUntilFailureReadinessCheck
+)
+
+func (h HealthcheckType) String() string {
+	return [...]string{"Startup", "Liveness", "UntilSuccessReadiness", "UntilFailureReadiness"}[h]
+}
+
+type CheckProtocol int
+
+const (
+	HTTPCheck CheckProtocol = iota
+	TCPCheck
+)
+
+func (c CheckProtocol) String() string {
+	return [...]string{"HTTP", "TCP"}[c]
+}


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
The proposed change is to improve the observability of failed Liveness Checks by emitting a metric.
https://github.com/cloudfoundry/diego-release/issues/953

Backward Compatibility
---------------
Breaking Change? **No**
