### PR TITLE
Ignore G110 for app asset decompression as it's bounded by container FS quota

### DIFF
--- a/depot/steps/upload_step.go
+++ b/depot/steps/upload_step.go
@@ -128,6 +128,7 @@ func (step *uploadStep) Run(signals <-chan os.Signal, ready chan<- struct{}) (er
 		os.Remove(finalFileLocation)
 	}()
 
+	// #nosec - G110 - We're fine with unbounded file decompression here as we have container filesystem quotas that will prevent this from eating up the entire diego cell disk space
 	_, err = io.Copy(tempFile, tarStream)
 	if err != nil {
 		step.logger.Error("failed-to-copy-stream", err)


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Ignores G110 becuase we have different filesystem limits guarding against this


Backward Compatibility
---------------
Breaking Change? No