### PR TITLE
fix: explicitly name metrics to pass linter

### DIFF
--- a/depot/steps/emit_check_failure_metric_step_test.go
+++ b/depot/steps/emit_check_failure_metric_step_test.go
@@ -114,6 +114,17 @@ var _ = Describe("EmitCheckFailureMetricStep", func() {
 					Expect(name).To(Equal("TCPLivenessChecksFailedCount"))
 				})
 			})
+
+			Context("when HealthCheckType is not Liveness", func() {
+				BeforeEach(func() {
+					checkType = executor.IsUntilFailureReadinessCheck
+					checkProtocol = executor.TCPCheck
+				})
+
+				It("should not emit any metric", func() {
+					Eventually(fakeMetronClient.IncrementCounterCallCount).Should(Equal(0))
+				})
+			})
 		})
 	})
 


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
To pass the metrics linter


Backward Compatibility
---------------
Breaking Change? No
