### PR TITLE
Update the rootFses to be an array instead of a map

### DIFF
--- a/initializer/configuration/configuration.go
+++ b/initializer/configuration/configuration.go
@@ -63,7 +63,7 @@ func GetRootFSSizes(
 	gardenClient garden_client.Client,
 	guidGenerator guidgen.Generator,
 	containerOwnerName string,
-	rootFSes map[string]string,
+	rootFSes []string,
 ) (RootFSSizer, error) {
 	rootFSSizes := make(map[string]uint64)
 

--- a/initializer/configuration/configuration_test.go
+++ b/initializer/configuration/configuration_test.go
@@ -264,7 +264,7 @@ var _ = Describe("configuration", func() {
 	Describe("GetRootFSSizes", func() {
 		var (
 			logger   lager.Logger
-			rootFSes map[string]string
+			rootFSes []string
 
 			fakeGuidGen  *fakeguidgen.FakeGenerator
 			guidToRootFS map[string]string
@@ -275,9 +275,9 @@ var _ = Describe("configuration", func() {
 
 		BeforeEach(func() {
 			logger = lagertest.NewTestLogger("configuration")
-			rootFSes = map[string]string{
-				"rootFS1": "/rootFS1/path",
-				"rootFS2": "/rootFS2/path",
+			rootFSes = []string{
+				"/rootFS1/path",
+				"/rootFS2/path",
 			}
 
 			fakeGuidGen = new(fakeguidgen.FakeGenerator)
@@ -293,8 +293,8 @@ var _ = Describe("configuration", func() {
 		Context("when container with provided rootFS is created", func() {
 			BeforeEach(func() {
 				expectedMetrics := map[string]garden.ContainerMetricsEntry{
-					"rootfs-c-g1": garden.ContainerMetricsEntry{Metrics: garden.Metrics{DiskStat: garden.ContainerDiskStat{TotalBytesUsed: uint64(150 * 1024 * 1024), ExclusiveBytesUsed: uint64(50 * 1024 * 1024)}}},
-					"rootfs-c-g2": garden.ContainerMetricsEntry{Metrics: garden.Metrics{DiskStat: garden.ContainerDiskStat{TotalBytesUsed: uint64(32 * 1024 * 1024), ExclusiveBytesUsed: uint64(8*1024*1024 - 5)}}},
+					"rootfs-c-g1": {Metrics: garden.Metrics{DiskStat: garden.ContainerDiskStat{TotalBytesUsed: uint64(150 * 1024 * 1024), ExclusiveBytesUsed: uint64(50 * 1024 * 1024)}}},
+					"rootfs-c-g2": {Metrics: garden.Metrics{DiskStat: garden.ContainerDiskStat{TotalBytesUsed: uint64(32 * 1024 * 1024), ExclusiveBytesUsed: uint64(8*1024*1024 - 5)}}},
 				}
 				gardenClient.Connection.BulkMetricsReturnsOnCall(0, expectedMetrics, nil)
 			})
@@ -346,8 +346,8 @@ var _ = Describe("configuration", func() {
 
 			Context("when the rootfs URI query string has been augmented with a query/scheme/host/etc.", func() {
 				BeforeEach(func() {
-					rootFSes = map[string]string{
-						"rootFS1": "/rootFS1/path",
+					rootFSes = []string{
+						"/rootFS1/path",
 					}
 				})
 
@@ -366,8 +366,8 @@ var _ = Describe("configuration", func() {
 
 			Context("when a preloaded rootfs URI is not just a simple path", func() {
 				BeforeEach(func() {
-					rootFSes = map[string]string{
-						"rootFS1": "somescheme:///rootFS1/path",
+					rootFSes = []string{
+						"somescheme:///rootFS1/path",
 					}
 				})
 
@@ -379,8 +379,8 @@ var _ = Describe("configuration", func() {
 
 			Context("when a preloaded rootfs URI is an invalid URI", func() {
 				BeforeEach(func() {
-					rootFSes = map[string]string{
-						"rootFS1": "/some/path/that/is/%invalid",
+					rootFSes = []string{
+						"/some/path/that/is/%invalid",
 					}
 				})
 

--- a/initializer/initializer.go
+++ b/initializer/initializer.go
@@ -157,25 +157,13 @@ var (
 	metricsWorkPool, readWorkPool      *workpool.WorkPool
 )
 
-func Initialize(
-	logger lager.Logger,
-	config ExecutorConfig,
-	cellID string,
-	zone string,
-	rootFSes map[string]string,
-	metronClient loggingclient.IngressClient,
+func Initialize(logger lager.Logger, config ExecutorConfig, cellID, zone string,
+	rootFSes []string, metronClient loggingclient.IngressClient,
 	clock clock.Clock,
-) (
-	executor.Client,
-	*containermetrics.StatsReporter,
-	grouper.Members,
-	error,
-) {
-
+) (executor.Client, *containermetrics.StatsReporter, grouper.Members, error) {
 	var gardenHealthcheckRootFS string
-	for _, rootFSPath := range rootFSes {
-		gardenHealthcheckRootFS = rootFSPath
-		break
+	if len(rootFSes) > 0 {
+		gardenHealthcheckRootFS = rootFSes[len(rootFSes)-1]
 	}
 
 	postSetupHook, err := shlex.Split(config.PostSetupHook)

--- a/initializer/initializer_test.go
+++ b/initializer/initializer_test.go
@@ -130,7 +130,7 @@ var _ = Describe("Initializer", func() {
 		config.GardenAddr = fakeGarden.HTTPTestServer.Listener.Addr().String()
 		config.GardenNetwork = "tcp"
 		go func() {
-			rootFSes := map[string]string{}
+			rootFSes := []string{}
 			_, _, _, err := initializer.Initialize(logger, config, "cell-id", "some-zone", rootFSes, fakeMetronClient, fakeClock)
 			errCh <- err
 			close(done)
@@ -194,7 +194,7 @@ var _ = Describe("Initializer", func() {
 					if r.FormValue(healthcheckTagQueryParam) == gardenhealth.HealthcheckTagValue {
 						ghttp.RespondWithJSONEncoded(http.StatusOK, struct{}{})(w, r)
 					} else {
-						ghttp.RespondWithJSONEncoded(http.StatusOK, map[string][]string{"handles": []string{"cnr1", "cnr2"}})(w, r)
+						ghttp.RespondWithJSONEncoded(http.StatusOK, map[string][]string{"handles": {"cnr1", "cnr2"}})(w, r)
 					}
 				},
 			)
@@ -718,7 +718,6 @@ var _ = Describe("Initializer", func() {
 				config.CachePath = ""
 
 				fakeCertPoolRetriever.SystemCertsReturns(x509.NewCertPool(), nil)
-
 			})
 			It("returns an error", func() {
 				certBytes, err := os.ReadFile(config.PathToTLSCACert)


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
The PR makes sure the FSes are always used in a consistent way. The map was removed in favour of an array. The FSes should be stored in ascending order, ie. [ cflinuxfs3, cflinuxfs4 ]

The github issue: https://github.com/cloudfoundry/diego-release/issues/983

Backward Compatibility
---------------
Breaking Change? **No**
No breaking changes, just making sure the fses are used in a consistent way
