### PR TITLE
Adjust the way the gardenHealthCheckRootFS is selected

### DIFF
--- a/initializer/initializer.go
+++ b/initializer/initializer.go
@@ -163,6 +163,7 @@ func Initialize(
 	cellID string,
 	zone string,
 	rootFSes map[string]string,
+	gardenHealthcheckRootFS string,
 	metronClient loggingclient.IngressClient,
 	clock clock.Clock,
 ) (
@@ -171,13 +172,6 @@ func Initialize(
 	grouper.Members,
 	error,
 ) {
-
-	var gardenHealthcheckRootFS string
-	for _, rootFSPath := range rootFSes {
-		gardenHealthcheckRootFS = rootFSPath
-		break
-	}
-
 	postSetupHook, err := shlex.Split(config.PostSetupHook)
 	if err != nil {
 		logger.Error("failed-to-parse-post-setup-hook", err)

--- a/initializer/initializer.go
+++ b/initializer/initializer.go
@@ -163,7 +163,7 @@ func Initialize(
 	cellID string,
 	zone string,
 	rootFSes map[string]string,
-	gardenHealthcheckRootFS string,
+	sidecarRootFSPath string,
 	metronClient loggingclient.IngressClient,
 	clock clock.Clock,
 ) (
@@ -172,6 +172,17 @@ func Initialize(
 	grouper.Members,
 	error,
 ) {
+	var gardenHealthcheckRootFS string
+	if sidecarRootFSPath == "" {
+		for _, rootFSPath := range rootFSes {
+			gardenHealthcheckRootFS = rootFSPath
+			break
+		}
+	} else {
+		gardenHealthcheckRootFS = sidecarRootFSPath
+	}
+	logger.Info("garden-healthcheck-rootfs", lager.Data{"rootfs": gardenHealthcheckRootFS})
+
 	postSetupHook, err := shlex.Split(config.PostSetupHook)
 	if err != nil {
 		logger.Error("failed-to-parse-post-setup-hook", err)

--- a/initializer/initializer_test.go
+++ b/initializer/initializer_test.go
@@ -131,7 +131,8 @@ var _ = Describe("Initializer", func() {
 		config.GardenNetwork = "tcp"
 		go func() {
 			rootFSes := map[string]string{}
-			_, _, _, err := initializer.Initialize(logger, config, "cell-id", "some-zone", rootFSes, fakeMetronClient, fakeClock)
+			sidecarFS := "some-fs"
+			_, _, _, err := initializer.Initialize(logger, config, "cell-id", "some-zone", rootFSes, sidecarFS, fakeMetronClient, fakeClock)
 			errCh <- err
 			close(done)
 		}()
@@ -194,7 +195,7 @@ var _ = Describe("Initializer", func() {
 					if r.FormValue(healthcheckTagQueryParam) == gardenhealth.HealthcheckTagValue {
 						ghttp.RespondWithJSONEncoded(http.StatusOK, struct{}{})(w, r)
 					} else {
-						ghttp.RespondWithJSONEncoded(http.StatusOK, map[string][]string{"handles": []string{"cnr1", "cnr2"}})(w, r)
+						ghttp.RespondWithJSONEncoded(http.StatusOK, map[string][]string{"handles": {"cnr1", "cnr2"}})(w, r)
 					}
 				},
 			)
@@ -718,7 +719,6 @@ var _ = Describe("Initializer", func() {
 				config.CachePath = ""
 
 				fakeCertPoolRetriever.SystemCertsReturns(x509.NewCertPool(), nil)
-
 			})
 			It("returns an error", func() {
 				certBytes, err := os.ReadFile(config.PathToTLSCACert)

--- a/initializer/initializer_test.go
+++ b/initializer/initializer_test.go
@@ -131,8 +131,8 @@ var _ = Describe("Initializer", func() {
 		config.GardenNetwork = "tcp"
 		go func() {
 			rootFSes := map[string]string{}
-			sidecarFS := "some-fs"
-			_, _, _, err := initializer.Initialize(logger, config, "cell-id", "some-zone", rootFSes, sidecarFS, fakeMetronClient, fakeClock)
+			sidecarRootFSPath := ""
+			_, _, _, err := initializer.Initialize(logger, config, "cell-id", "some-zone", rootFSes, sidecarRootFSPath, fakeMetronClient, fakeClock)
 			errCh <- err
 			close(done)
 		}()


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
The PR makes sure the FSes are used in a consistent way. We have added a SidecarRootFS that will store the FS to be used for the envoy & healthchecks.

The github issue: https://github.com/cloudfoundry/diego-release/issues/983

Backward Compatibility
---------------
Breaking Change? **No**
No breaking changes, just making sure the fses are used in a consistent way
<!---