### PR TITLE
Move logic for figuring out sidecarRootFSPath to rep

### DIFF
--- a/initializer/initializer.go
+++ b/initializer/initializer.go
@@ -173,16 +173,7 @@ func Initialize(
 	grouper.Members,
 	error,
 ) {
-	var gardenHealthcheckRootFS string
-	if sidecarRootFSPath == "" {
-		for _, rootFSPath := range rootFSes {
-			gardenHealthcheckRootFS = rootFSPath
-			break
-		}
-	} else {
-		gardenHealthcheckRootFS = sidecarRootFSPath
-	}
-	logger.Info("garden-healthcheck-rootfs", lager.Data{"rootfs": gardenHealthcheckRootFS})
+	logger.Info("garden-healthcheck-rootfs", lager.Data{"rootfs": sidecarRootFSPath})
 
 	postSetupHook, err := shlex.Split(config.PostSetupHook)
 	if err != nil {
@@ -270,7 +261,7 @@ func Initialize(
 		config.PostSetupUser,
 		config.EnableDeclarativeHealthcheck,
 		config.EnableHealtcheckMetrics,
-		gardenHealthcheckRootFS,
+		sidecarRootFSPath,
 		config.EnableContainerProxy,
 		time.Duration(config.EnvoyDrainTimeout),
 	)
@@ -382,7 +373,7 @@ func Initialize(
 	}
 
 	gardenHealthcheck := gardenhealth.NewChecker(
-		gardenHealthcheckRootFS,
+		sidecarRootFSPath,
 		config.HealthCheckContainerOwnerName,
 		time.Duration(config.GardenHealthcheckCommandRetryPause),
 		healthcheckSpec,


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
To be used in conjuction with https://github.com/cloudfoundry/rep/pull/68


Backward Compatibility
---------------
Breaking Change? **No**
