### PR TITLE
update key-size for test certs to be ready for go 1.24

### DIFF
--- a/depot/containerstore/proxy_config_handler_test.go
+++ b/depot/containerstore/proxy_config_handler_test.go
@@ -997,7 +997,7 @@ var _ = Describe("ProxyConfigHandler", func() {
 
 func generateCertAndKey() (string, string, *big.Int) {
 	// generate a real cert
-	privateKey, err := rsa.GenerateKey(rand.Reader, 512)
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	Expect(err).ToNot(HaveOccurred())
 	template := x509.Certificate{
 		SerialNumber: new(big.Int),


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
rsa.GenerateKey will fail if bitsize < 1024 in go 1.24. This is only used in tests.

From release notes:
> [GenerateKey](https://tip.golang.org/pkg/crypto/rsa#GenerateKey) now returns an error if a key of less than 1024 bits is requested. All Sign, Verify, Encrypt, and Decrypt methods now return an error if used with a key smaller than 1024 bits. Such keys are insecure and should not be used. [GODEBUG setting](https://tip.golang.org/doc/godebug) rsa1024min=0 restores the old behavior, but we recommend doing so only if necessary and only in tests, for example by adding a //go:debug rsa1024min=0 line to a test file. A new GenerateKey [example](https://tip.golang.org/pkg/crypto/rsa#example-GenerateKey-TestKey) provides an easy-to-use standard 2048-bit test key.


Backward Compatibility
---------------
Breaking Change? No.
