### PR TITLE
Fix error with fmt.Sprintf and non-constant formats

### DIFF
--- a/depot/log_streamer/log_streamer_test.go
+++ b/depot/log_streamer/log_streamer_test.go
@@ -132,8 +132,8 @@ var _ = Describe("LogStreamer", func() {
 				maxLogLinesPerSecond, maxLogBytesPerSecond = 1, 100
 				streamer = log_streamer.New(logConfig, fakeClient, maxLogLinesPerSecond, maxLogBytesPerSecond, metricReportInterval)
 
-				fmt.Fprintf(streamer.Stdout(), strings.Repeat("a", 1000)+"\n")
-				fmt.Fprintf(streamer.Stdout(), "bbbbbbb\n")
+				fmt.Fprintln(streamer.Stdout(), strings.Repeat("a", 1000))
+				fmt.Fprintln(streamer.Stdout(), "bbbbbbb")
 			})
 
 			It("causes outages of logs", func() {
@@ -454,7 +454,7 @@ var _ = Describe("LogStreamer", func() {
 					message = strings.Repeat("7", log_streamer.MAX_MESSAGE_SIZE)
 					Expect([]byte(message)).To(HaveLen(log_streamer.MAX_MESSAGE_SIZE), "Ensure that the byte representation of our message is under the limit")
 
-					fmt.Fprintf(streamer.Stdout(), message+"\n")
+					fmt.Fprintln(streamer.Stdout(), message)
 				})
 
 				It("should not break the message up and send a single messages", func() {
@@ -512,8 +512,8 @@ var _ = Describe("LogStreamer", func() {
 					})
 
 					It("emits both messages correctly", func() {
-						fmt.Fprintf(streamer.Stdout(), message+utfChar[0:2])
-						fmt.Fprintf(streamer.Stdout(), utfChar+"\n")
+						fmt.Fprint(streamer.Stdout(), message+utfChar[0:2])
+						fmt.Fprintln(streamer.Stdout(), utfChar)
 
 						Expect(fakeClient.SendAppLogCallCount()).To(Equal(2))
 
@@ -579,7 +579,7 @@ var _ = Describe("LogStreamer", func() {
 		})
 
 		It("should handle long messages", func() {
-			fmt.Fprintf(streamer.Stderr(), strings.Repeat("e", log_streamer.MAX_MESSAGE_SIZE+1)+"\n")
+			fmt.Fprintln(streamer.Stderr(), strings.Repeat("e", log_streamer.MAX_MESSAGE_SIZE+1))
 			Expect(fakeClient.SendAppErrorLogCallCount()).To(Equal(2))
 
 			msg, _, _ := fakeClient.SendAppErrorLogArgsForCall(0)

--- a/depot/steps/download_step.go
+++ b/depot/steps/download_step.go
@@ -91,8 +91,8 @@ func (step *downloadStep) perform() error {
 			errString = "Downloading failed"
 		}
 
-		step.emitError(fmt.Sprintf("%s\n", errString))
-		return NewEmittableError(err, errString)
+		step.emitError("%s\n", errString)
+		return NewEmittableError(err, "%s", errString)
 	}
 
 	err = step.streamIn(step.model.To, downloadedFile)
@@ -103,8 +103,9 @@ func (step *downloadStep) perform() error {
 		} else {
 			errString = fmt.Sprintf("Copying into the container failed: %v", err)
 		}
-		step.emitError(fmt.Sprintf("%s\n", errString))
-		return NewEmittableError(err, errString)
+
+		step.emitError("%s\n", errString)
+		return NewEmittableError(err, "%s", errString)
 	}
 
 	if downloadedSize != 0 {

--- a/depot/steps/output_wrapper_step.go
+++ b/depot/steps/output_wrapper_step.go
@@ -52,5 +52,5 @@ func (step *outputWrapperStep) Run(signals <-chan os.Signal, ready chan<- struct
 	if step.prefix != "" {
 		msg = step.prefix + ": " + msg
 	}
-	return NewEmittableError(subStepErr, msg)
+	return NewEmittableError(subStepErr, "%s", msg)
 }

--- a/depot/steps/run_step.go
+++ b/depot/steps/run_step.go
@@ -242,7 +242,7 @@ func (step *runStep) Run(signals <-chan os.Signal, ready chan<- struct{}) error 
 
 			if exitStatus != 0 {
 				logger.Error("run-step-failed-with-nonzero-status-code", errors.New(exitErrorMessage), lager.Data{"status-code": exitStatus})
-				return NewEmittableError(nil, emittableExitErrorMessage)
+				return NewEmittableError(nil, "%s", emittableExitErrorMessage)
 			}
 
 			return nil

--- a/depot/steps/run_step_test.go
+++ b/depot/steps/run_step_test.go
@@ -449,7 +449,7 @@ var _ = Describe("RunAction", func() {
 
 				It("should return an emittable error with the exit code", func() {
 					errMsg := fmt.Sprintf("%s: Exited with status 19", testLogSource)
-					Eventually(process.Wait()).Should(Receive(MatchError(steps.NewEmittableError(nil, errMsg))))
+					Eventually(process.Wait()).Should(Receive(MatchError(steps.NewEmittableError(nil, "%s", errMsg))))
 				})
 			})
 
@@ -460,7 +460,7 @@ var _ = Describe("RunAction", func() {
 
 				It("should return an emittable error with the exit code", func() {
 					errMsg := fmt.Sprintf("%s: Exited with status 19", testLogSource)
-					Eventually(process.Wait()).Should(Receive(MatchError(steps.NewEmittableError(nil, errMsg))))
+					Eventually(process.Wait()).Should(Receive(MatchError(steps.NewEmittableError(nil, "%s", errMsg))))
 				})
 			})
 		})
@@ -534,7 +534,7 @@ var _ = Describe("RunAction", func() {
 
 			It("returns an emittable error", func() {
 				errMsg := fmt.Sprintf("%s: Exited with status 19 (out of memory)", testLogSource)
-				Eventually(process.Wait()).Should(Receive(MatchError(steps.NewEmittableError(nil, errMsg))))
+				Eventually(process.Wait()).Should(Receive(MatchError(steps.NewEmittableError(nil, "%s", errMsg))))
 			})
 		})
 
@@ -552,7 +552,7 @@ var _ = Describe("RunAction", func() {
 
 			It("returns an emittable error", func() {
 				errMsg := fmt.Sprintf("%s: Exited with status 19 (out of memory)", testLogSource)
-				Eventually(process.Wait()).Should(Receive(MatchError(steps.NewEmittableError(nil, errMsg))))
+				Eventually(process.Wait()).Should(Receive(MatchError(steps.NewEmittableError(nil, "%s", errMsg))))
 			})
 		})
 

--- a/depot/steps/timeout_step.go
+++ b/depot/steps/timeout_step.go
@@ -46,7 +46,7 @@ func (step *timeoutStep) Run(signals <-chan os.Signal, ready chan<- struct{}) (e
 			step.logger.Error("timed-out", nil)
 			subStepSignals <- os.Interrupt
 			err := <-resultCh
-			return NewEmittableError(err, emittableMessage(step.timeout, err))
+			return NewEmittableError(err, "%s", emittableMessage(step.timeout, err))
 		}
 	}
 }

--- a/depot/steps/upload_step.go
+++ b/depot/steps/upload_step.go
@@ -91,7 +91,7 @@ func (step *uploadStep) Run(signals <-chan os.Signal, ready chan<- struct{}) (er
 		step.logger.Error("failed-to-create-tmp-dir", err)
 		errString := step.artifactErrString(ErrCreateTmpDir)
 		step.emitError(errString)
-		return NewEmittableError(err, errString)
+		return NewEmittableError(err, "%s", errString)
 	}
 
 	defer os.RemoveAll(tempDir)
@@ -101,7 +101,7 @@ func (step *uploadStep) Run(signals <-chan os.Signal, ready chan<- struct{}) (er
 		step.logger.Error("failed-to-stream-out", err)
 		errString := step.artifactErrString(ErrEstablishStream)
 		step.emitError(errString)
-		return NewEmittableError(err, errString)
+		return NewEmittableError(err, "%s", errString)
 	}
 	defer outStream.Close()
 
@@ -112,7 +112,7 @@ func (step *uploadStep) Run(signals <-chan os.Signal, ready chan<- struct{}) (er
 		step.logger.Error("failed-to-read-stream", err)
 		errString := step.artifactErrString(ErrReadTar)
 		step.emitError(errString)
-		return NewEmittableError(err, errString)
+		return NewEmittableError(err, "%s", errString)
 	}
 
 	tempFile, err := os.CreateTemp(step.tempDir, "compressed")
@@ -120,7 +120,7 @@ func (step *uploadStep) Run(signals <-chan os.Signal, ready chan<- struct{}) (er
 		step.logger.Error("failed-to-create-tmp-dir", err)
 		errString := step.artifactErrString(ErrCreateTmpFile)
 		step.emitError(errString)
-		return NewEmittableError(err, errString)
+		return NewEmittableError(err, "%s", errString)
 	}
 	finalFileLocation := tempFile.Name()
 	defer func() {
@@ -140,7 +140,7 @@ func (step *uploadStep) Run(signals <-chan os.Signal, ready chan<- struct{}) (er
 		step.logger.Error("failed-to-copy-stream", err)
 		errString := step.artifactErrString(ErrCopyStreamToTmp)
 		step.emitError(errString)
-		return NewEmittableError(err, errString)
+		return NewEmittableError(err, "%s", errString)
 	}
 
 	finished := make(chan struct{})

--- a/depot/steps/upload_step_test.go
+++ b/depot/steps/upload_step_test.go
@@ -462,7 +462,8 @@ var _ = Describe("UploadStep", func() {
 				It("should emits an error with the artifact name", func() {
 					err := <-ifrit.Invoke(step).Wait()
 					Expect(err).To(HaveOccurred())
-					Expect(err).To(MatchError(steps.NewEmittableError(errStream, fmt.Sprintf("%s for %s", steps.ErrEstablishStream, "artifact"))))
+					errString := fmt.Sprintf("%s for %s", steps.ErrEstablishStream, "artifact")
+					Expect(err).To(MatchError(steps.NewEmittableError(errStream, "%s", errString)))
 				})
 
 				It("should log error with artifact name", func() {
@@ -505,7 +506,8 @@ var _ = Describe("UploadStep", func() {
 				It("should emits an error with the artifact name", func() {
 					err := <-ifrit.Invoke(step).Wait()
 					Expect(err).To(HaveOccurred())
-					Expect(err).To(MatchError(steps.NewEmittableError(errStream, fmt.Sprintf("%s for %s", steps.ErrReadTar, "artifact"))))
+					errString := fmt.Sprintf("%s for %s", steps.ErrReadTar, "artifact")
+					Expect(err).To(MatchError(steps.NewEmittableError(errStream, "%s", errString)))
 				})
 
 				It("should log error with artifact name", func() {


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
go 1.24.1 introduces a check on Printf (https://github.com/golang/go/issues/60529).  This typically happens when a *printf call doesn't specify the args for the format string.  


Backward Compatibility
---------------
Breaking Change? **No**
