### PR TITLE
Configurable default HealthCheck timeout

### DIFF
--- a/depot/transformer/transformer.go
+++ b/depot/transformer/transformer.go
@@ -83,9 +83,13 @@ func WithSidecarRootfs(
 	}
 }
 
-func WithDeclarativeHealthchecks(timeout time.Duration) Option {
+func WithDeclarativeHealthChecks(timeout time.Duration) Option {
 	return func(t *transformer) {
 		t.useDeclarativeHealthCheck = true
+
+		if timeout <= 0 {
+			timeout = time.Duration(DefaultDeclarativeHealthcheckRequestTimeout) * time.Millisecond
+		}
 		t.declarativeHealthCheckDefaultTimeout = timeout
 	}
 }
@@ -823,10 +827,6 @@ func (t *transformer) transformReadinessCheckDefinition(
 func (t *transformer) applyCheckDefaults(timeout int, interval time.Duration, path string) (int, time.Duration, string) {
 	if timeout <= 0 {
 		timeout = int(t.declarativeHealthCheckDefaultTimeout / time.Millisecond)
-	}
-	if timeout <= 0 {
-		// fallback to 1000 if still invalid
-		timeout = DefaultDeclarativeHealthcheckRequestTimeout
 	}
 
 	if path == "" {

--- a/depot/transformer/transformer_test.go
+++ b/depot/transformer/transformer_test.go
@@ -642,7 +642,8 @@ var _ = Describe("Transformer", func() {
 
 			Context("when declarative healthchecks are enabled", func() {
 				BeforeEach(func() {
-					options = append(options, transformer.WithDeclarativeHealthchecks())
+					declarativeHealthCheckTimeout := 42 * time.Second
+					options = append(options, transformer.WithDeclarativeHealthchecks(declarativeHealthCheckTimeout))
 
 					container.StartTimeoutMs = 1000
 				})
@@ -848,7 +849,7 @@ var _ = Describe("Transformer", func() {
 											Path: filepath.Join(transformer.HealthCheckDstPath, "healthcheck"),
 											Args: []string{
 												"-port=8989",
-												"-timeout=1000ms",
+												"-timeout=42000ms",
 												"-uri=/",
 												fmt.Sprintf("-until-ready-interval=%s", unhealthyMonitoringInterval),
 											},
@@ -1099,12 +1100,12 @@ var _ = Describe("Transformer", func() {
 										Expect(paths).To(ContainElement(filepath.Join(transformer.HealthCheckDstPath, "healthcheck")))
 										Expect(args).To(ContainElement([]string{
 											"-port=5432",
-											"-timeout=1000ms",
+											"-timeout=42000ms",
 											"-until-ready-interval=1ms",
 										}))
 										Expect(args).To(ContainElement([]string{
 											"-port=5432",
-											"-timeout=1000ms",
+											"-timeout=42000ms",
 											"-readiness-interval=1s",
 										}))
 									})
@@ -1400,7 +1401,7 @@ var _ = Describe("Transformer", func() {
 							Expect(paths).To(ContainElement(filepath.Join(transformer.HealthCheckDstPath, "healthcheck")))
 							Expect(args).To(ContainElement([]string{
 								"-port=6432",
-								"-timeout=1000ms",
+								"-timeout=42000ms",
 								"-uri=/",
 								"-startup-interval=1ms",
 								"-startup-timeout=1s",
@@ -1640,7 +1641,7 @@ var _ = Describe("Transformer", func() {
 								Expect(paths).To(ContainElement(filepath.Join(transformer.HealthCheckDstPath, "healthcheck")))
 								Expect(args).To(ContainElement([]string{
 									"-port=6432",
-									"-timeout=1000ms",
+									"-timeout=42000ms",
 									"-uri=/",
 									"-liveness-interval=1s",
 								}))
@@ -1745,7 +1746,7 @@ var _ = Describe("Transformer", func() {
 							Expect(paths).To(ContainElement(filepath.Join(transformer.HealthCheckDstPath, "healthcheck")))
 							Expect(args).To(ContainElement([]string{
 								"-port=6432",
-								"-timeout=1000ms",
+								"-timeout=42000ms",
 								"-startup-interval=1ms",
 								"-startup-timeout=1s",
 							}))
@@ -1829,7 +1830,7 @@ var _ = Describe("Transformer", func() {
 								Expect(paths).To(ContainElement(filepath.Join(transformer.HealthCheckDstPath, "healthcheck")))
 								Expect(args).To(ContainElement([]string{
 									"-port=6432",
-									"-timeout=1000ms",
+									"-timeout=42000ms",
 									"-liveness-interval=1s",
 								}))
 							})

--- a/initializer/initializer.go
+++ b/initializer/initializer.go
@@ -104,6 +104,7 @@ type ExecutorConfig struct {
 	EnableContainerProxy                  bool                  `json:"enable_container_proxy,omitempty"`
 	EnableContainerProxyHealthChecks      bool                  `json:"enable_container_proxy_healthcheck,omitempty"`
 	EnableDeclarativeHealthcheck          bool                  `json:"enable_declarative_healthcheck,omitempty"`
+	DeclarativeHealthCheckDefaultTimeout  durationjson.Duration `json:"declarative_healthcheck_default_timeout,omitempty"`
 	EnableHealtcheckMetrics               bool                  `json:"enable_healthcheck_metrics,omitempty"`
 	EnableUnproxiedPortMappings           bool                  `json:"enable_unproxied_port_mappings"`
 	EnvoyConfigRefreshDelay               durationjson.Duration `json:"envoy_config_refresh_delay"`
@@ -268,6 +269,7 @@ func Initialize(
 		time.Duration(config.EnvoyDrainTimeout),
 		config.EnableContainerProxyHealthChecks,
 		time.Duration(config.ProxyHealthCheckInterval),
+		time.Duration(config.DeclarativeHealthCheckDefaultTimeout),
 	)
 
 	hub := event.NewHub()
@@ -574,6 +576,8 @@ func initializeTransformer(
 	drainWait time.Duration,
 	enableProxyHealthChecks bool,
 	proxyHealthCheckInterval time.Duration,
+	declarativeHealthCheckDefaultTimeout time.Duration,
+
 ) transformer.Transformer {
 	var options []transformer.Option
 	compressor := compressor.NewTgz()
@@ -581,7 +585,7 @@ func initializeTransformer(
 	options = append(options, transformer.WithSidecarRootfs(declarativeHealthcheckRootFS))
 
 	if useDeclarativeHealthCheck {
-		options = append(options, transformer.WithDeclarativeHealthchecks())
+		options = append(options, transformer.WithDeclarativeHealthchecks(declarativeHealthCheckDefaultTimeout))
 	}
 
 	if emitHealthCheckMetrics {

--- a/initializer/initializer.go
+++ b/initializer/initializer.go
@@ -585,7 +585,7 @@ func initializeTransformer(
 	options = append(options, transformer.WithSidecarRootfs(declarativeHealthcheckRootFS))
 
 	if useDeclarativeHealthCheck {
-		options = append(options, transformer.WithDeclarativeHealthchecks(declarativeHealthCheckDefaultTimeout))
+		options = append(options, transformer.WithDeclarativeHealthChecks(declarativeHealthCheckDefaultTimeout))
 	}
 
 	if emitHealthCheckMetrics {
@@ -768,6 +768,11 @@ func (config *ExecutorConfig) Validate(logger lager.Logger) bool {
 
 	if config.PostSetupHook != "" && config.PostSetupUser == "" {
 		logger.Error("post-setup-hook-requires-a-user", nil)
+		valid = false
+	}
+
+	if config.EnableDeclarativeHealthcheck && time.Duration(config.DeclarativeHealthCheckDefaultTimeout) <= 0 {
+		logger.Error("declarative_healthcheck_default_timeout", nil)
 		valid = false
 	}
 


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Make the declarative Liveness Healthcheck default timeout configurable.


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
