### PR TITLE
Fix codependency bug for sidecars while preserving daemonization

### DIFF
--- a/depot/transformer/transformer.go
+++ b/depot/transformer/transformer.go
@@ -584,7 +584,7 @@ func (t *transformer) StepsRunner(
 	}
 
 	if len(substeps) > 1 {
-		longLivedAction = steps.NewCodependent(substeps, false, true)
+		longLivedAction = steps.NewCodependent(substeps, false, len(container.Sidecars) > 0)
 	} else {
 		longLivedAction = action
 	}


### PR DESCRIPTION
Made-with: Cursor

- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
----
Fixes previous fix to preserve the daemonization workflow issue caught in an inigo test


Backward Compatibility
---------------
Breaking Change? no