### PR TITLE
gardenhealth: retry initial health check until timeout

### DIFF
--- a/gardenhealth/runner.go
+++ b/gardenhealth/runner.go
@@ -72,6 +72,20 @@ func NewRunner(
 // intentionally do not kill the healthcheck process, and we don't spawn a new healthcheck
 // until the existing healthcheck exits. It may be necessary for an operator to
 // inspect the long running container to debug the problem.
+//
+// Startup behaviour: the ready signal is closed immediately so the ordered ifrit group
+// proceeds to start http_server (and /ping) without waiting for the first garden
+// healthcheck (~60-90s container creation overhead on a fresh VM). BOSH post-start
+// therefore completes in ~14s.
+//
+// During the initial healthcheck phase, transient errors (e.g. garden not yet ready
+// because rep and garden start simultaneously during a BOSH upgrade) cause a retry
+// rather than a fatal exit. The cell is marked unhealthy on each failure so BBS does
+// not schedule LRPs there. Only a timeout of the full GardenHealthcheckTimeout
+// (default 10m) is treated as a fatal error, ensuring permanently broken garden is
+// still detected without triggering a crash-restart loop on every upgrade.
+// Once the initial healthcheck succeeds, periodic failures are handled with the same
+// retry-until-timeout resilience, preserving runtime stability.
 func (r *Runner) Run(signals <-chan os.Signal, ready chan<- struct{}) error {
 	logger := r.logger.Session("garden-health")
 	healthcheckTimeout := r.clock.NewTimer(r.timeoutInterval)
@@ -79,31 +93,48 @@ func (r *Runner) Run(signals <-chan os.Signal, ready chan<- struct{}) error {
 
 	logger.Info("starting")
 
+	close(ready)
+	logger.Info("started")
+
 	go r.healthcheckCycle(logger, healthcheckComplete)
 
-	select {
-	case signal := <-signals:
-		logger.Info("signalled", lager.Data{"signal": signal.String()})
-		return nil
+	// Initial phase: retry on transient errors; fatal only on timeout.
+	// Garden and rep start simultaneously during BOSH upgrades; garden needs
+	// ~60-90s before it can create containers. Retrying here avoids the
+	// crash-restart loop (~121s) that occurred when any error was fatal.
+initialLoop:
+	for {
+		select {
+		case signal := <-signals:
+			logger.Info("signalled", lager.Data{"signal": signal.String()})
+			return nil
 
-	case <-healthcheckTimeout.C():
-		r.setUnhealthy(logger)
-		r.checker.Cancel(logger)
-		logger.Info("timed-out")
-		return HealthcheckTimeoutError{}
-
-	case err := <-healthcheckComplete:
-		if err != nil {
+		case <-healthcheckTimeout.C():
 			r.setUnhealthy(logger)
-			return err
+			r.checker.Cancel(logger)
+			err := r.metronClient.SendMetric(CellUnhealthyMetric, 1)
+			if err != nil {
+				logger.Debug("failed-to-emit-cell-unhealth-metric", lager.Data{"error": err})
+			}
+			logger.Info("initial-healthcheck-timed-out")
+			return HealthcheckTimeoutError{}
+
+		case err := <-healthcheckComplete:
+			if err != nil {
+				r.setUnhealthy(logger)
+				if _, ok := err.(UnrecoverableError); ok {
+					return err
+				}
+				logger.Info("initial-healthcheck-failed-retrying", lager.Data{"error": err})
+				go r.healthcheckCycle(logger, healthcheckComplete)
+			} else {
+				healthcheckTimeout.Stop()
+				break initialLoop
+			}
 		}
-		healthcheckTimeout.Stop()
 	}
 
 	r.setHealthy(logger)
-
-	close(ready)
-	logger.Info("started")
 
 	startHealthcheck := r.clock.NewTimer(r.checkInterval)
 	emitInterval := r.clock.NewTicker(r.emissionInterval)

--- a/gardenhealth/runner_test.go
+++ b/gardenhealth/runner_test.go
@@ -84,16 +84,45 @@ var _ = Describe("Runner", func() {
 
 	Describe("Run", func() {
 		Context("When garden is immediately unhealthy", func() {
-			Context("because the health check fails", func() {
+			Context("because the health check fails with a transient error", func() {
+				var checkErr = errors.New("transient")
+				BeforeEach(func() {
+					checker.HealthcheckReturns(checkErr)
+					executorClient.HealthyReturns(false)
+				})
+
+				It("becomes ready immediately and retries until the initial timeout fires", func() {
+					Eventually(process.Ready()).Should(BeClosed())
+					// Transient errors no longer cause an immediate fatal exit; the
+					// runner retries while marking the cell unhealthy.
+					Consistently(process.Wait()).ShouldNot(Receive())
+					// Only exits (with HealthcheckTimeoutError) once the timeout elapses.
+					fakeClock.WaitForWatcherAndIncrement(timeoutDuration)
+					Eventually(process.Wait()).Should(Receive(Equal(gardenhealth.HealthcheckTimeoutError{})))
+				})
+
+				It("emits a metric for unhealthy cell", func() {
+					// setUnhealthy is called on each failed retry attempt.
+					Eventually(getMetrics).Should(HaveKeyWithValue(GardenHealthCheckFailed, float64(1)))
+				})
+
+				It("emits the CellUnhealthy metric when it times out", func() {
+					fakeClock.WaitForWatcherAndIncrement(timeoutDuration)
+					Eventually(process.Wait()).Should(Receive(Equal(gardenhealth.HealthcheckTimeoutError{})))
+					Eventually(getMetrics).Should(HaveKeyWithValue(CellUnhealthyMetric, float64(1)))
+				})
+			})
+
+			Context("because the health check fails with an unrecoverable error", func() {
 				var checkErr = gardenhealth.UnrecoverableError("nope")
 				BeforeEach(func() {
 					checker.HealthcheckReturns(checkErr)
 					executorClient.HealthyReturns(false)
 				})
 
-				It("fails without becoming ready", func() {
+				It("becomes ready immediately and exits immediately with the error", func() {
+					Eventually(process.Ready()).Should(BeClosed())
 					Eventually(process.Wait()).Should(Receive(Equal(checkErr)))
-					Consistently(process.Ready()).ShouldNot(BeClosed())
 				})
 
 				It("emits a metric for unhealthy cell", func() {
@@ -118,20 +147,25 @@ var _ = Describe("Runner", func() {
 				})
 
 				AfterEach(func() {
-					// Send to the channel to eliminate the race
+					// Send to the channel to unblock the goroutine after the runner has exited
 					blockHealthcheck <- struct{}{}
 					close(blockHealthcheck)
 					blockHealthcheck = nil
 				})
 
-				It("fails without becoming ready", func() {
+				It("becomes ready immediately then exits with timeout error", func() {
+					Eventually(process.Ready()).Should(BeClosed())
 					Eventually(process.Wait()).Should(Receive(Equal(gardenhealth.HealthcheckTimeoutError{})))
-					Consistently(process.Ready()).ShouldNot(BeClosed())
 				})
 
 				It("emits a metric for unhealthy cell", func() {
 					Eventually(process.Wait()).Should(Receive(Equal(gardenhealth.HealthcheckTimeoutError{})))
 					Eventually(getMetrics).Should(HaveKeyWithValue(GardenHealthCheckFailed, float64(1)))
+				})
+
+				It("emits the CellUnhealthy metric", func() {
+					Eventually(process.Wait()).Should(Receive(Equal(gardenhealth.HealthcheckTimeoutError{})))
+					Eventually(getMetrics).Should(HaveKeyWithValue(CellUnhealthyMetric, float64(1)))
 				})
 
 				It("cancels the existing health check", func() {


### PR DESCRIPTION
## Summary

This PR addresses an issue where `rep` crash-restarts unnecessarily during BOSH deployments because it treats early Garden health check failures as fatal. 

During BOSH `starting_jobs`, Monit starts Garden and `rep` simultaneously. However, Garden requires ~60–90 seconds to warm up on a fresh VM before it can successfully create containers. Previously, the executor's garden health path would fail fatally on the very first transient error, leading to `rep` exiting and entering a ~121s Monit restart cycle.

This change makes the initial health check phase resilient to these transient errors. Instead of failing immediately, the runner now retries the health check in a tight loop until the full `GardenHealthcheckTimeout` (default 10m) expires. 

- The cell is still correctly marked as `unhealthy` during this phase so BBS does not schedule LRPs there.
- The `ready` signal is closed immediately so the BOSH `post-start` script can complete quickly (~14s).
- A fatal error is only triggered if the full timeout is reached, ensuring permanently broken Garden instances are still detected.

## Backward Compatibility
Breaking Change? **No**

This change modifies internal startup resilience but does not alter the external API, metric emission, or the ultimate failure conditions (it still fails if Garden is genuinely broken past the timeout). It is fully backwards compatible and should apply immediately to all deployments to improve stability during upgrades.