### PR TITLE
gofmt: fix indentation in transformer_test.go

### DIFF
--- a/depot/transformer/transformer_test.go
+++ b/depot/transformer/transformer_test.go
@@ -329,20 +329,20 @@ var _ = Describe("Transformer", func() {
 				startupIOCh := startupIO
 				livenessIOCh := livenessIO
 
-			startupCh = make(chan int)
-			startupProcess = makeProcess(startupCh)
+				startupCh = make(chan int)
+				startupProcess = makeProcess(startupCh)
 
-			livenessCh = make(chan int, 1)
-			// makeProcessWithSignal is required so that if the runner transitions
-			// to the liveness phase before the interrupt from a proxy failure
-			// reaches the healthCheckStep, the liveness process exits immediately
-			// on signal rather than blocking indefinitely on livenessCh.
-			livenessProcess = makeProcessWithSignal(livenessCh)
+				livenessCh = make(chan int, 1)
+				// makeProcessWithSignal is required so that if the runner transitions
+				// to the liveness phase before the interrupt from a proxy failure
+				// reaches the healthCheckStep, the liveness process exits immediately
+				// on signal rather than blocking indefinitely on livenessCh.
+				livenessProcess = makeProcessWithSignal(livenessCh)
 
-			healthcheckCallCount := int64(0)
-			gardenContainer.RunStub = func(spec garden.ProcessSpec, io garden.ProcessIO) (process garden.Process, err error) {
-				defer GinkgoRecover()
-				// get rid of race condition caused by write inside the BeforeEach
+				healthcheckCallCount := int64(0)
+				gardenContainer.RunStub = func(spec garden.ProcessSpec, io garden.ProcessIO) (process garden.Process, err error) {
+					defer GinkgoRecover()
+					// get rid of race condition caused by write inside the BeforeEach
 
 					processLock.Lock()
 					defer processLock.Unlock()


### PR DESCRIPTION
Restore consistent 4-tab indentation broken by commit 645a0bd2 ("Fix for go test failures with go1.26").

Summary
---------------
Fix a go formatting issue that is failing the diego-release pipeline.


Backward Compatibility
---------------
Breaking Change? No
