### PR TITLE
fix: report live disk capacity via syscall.Statfs in TotalResources

### DIFF
--- a/depot/depot.go
+++ b/depot/depot.go
@@ -3,6 +3,7 @@ package depot
 import (
 	"io"
 	"sync"
+	"syscall"
 
 	"code.cloudfoundry.org/executor"
 	"code.cloudfoundry.org/executor/depot/containerstore"
@@ -17,6 +18,7 @@ const ContainerStoppedBeforeRunMessage = "Container stopped by user"
 
 type client struct {
 	totalCapacity    executor.ExecutorResources
+	diskPath         string
 	containerStore   containerstore.ContainerStore
 	gardenClient     garden.Client
 	volmanClient     volman.Manager
@@ -40,9 +42,11 @@ func NewClient(
 	deletionWorkPool *workpool.WorkPool,
 	readWorkPool *workpool.WorkPool,
 	metricsWorkPool *workpool.WorkPool,
+	diskPath string,
 ) executor.Client {
 	return &client{
 		totalCapacity:    totalCapacity,
+		diskPath:         diskPath,
 		containerStore:   containerStore,
 		gardenClient:     gardenClient,
 		volmanClient:     volmanClient,
@@ -224,12 +228,17 @@ func (c *client) Ping(logger lager.Logger) error {
 }
 
 func (c *client) TotalResources(logger lager.Logger) (executor.ExecutorResources, error) {
-	totalCapacity := c.totalCapacity
-
+	diskMB := c.totalCapacity.DiskMB
+	if c.diskPath != "" {
+		var stat syscall.Statfs_t
+		if err := syscall.Statfs(c.diskPath, &stat); err == nil {
+			diskMB = int(int64(stat.Bavail) * int64(stat.Bsize) / (1024 * 1024))
+		}
+	}
 	return executor.ExecutorResources{
-		MemoryMB:   totalCapacity.MemoryMB,
-		DiskMB:     totalCapacity.DiskMB,
-		Containers: totalCapacity.Containers,
+		MemoryMB:   c.totalCapacity.MemoryMB,
+		DiskMB:     diskMB,
+		Containers: c.totalCapacity.Containers,
 	}, nil
 }
 

--- a/depot/depot_test.go
+++ b/depot/depot_test.go
@@ -3,6 +3,8 @@ package depot_test
 import (
 	"errors"
 	"io"
+	"math"
+	"os"
 	"time"
 
 	bbsmodels "code.cloudfoundry.org/bbs/models"
@@ -31,6 +33,7 @@ var _ = Describe("Depot", func() {
 		containerStore      *containerstorefakes.FakeContainerStore
 		resources           executor.ExecutorResources
 		volumeDrivers       []string
+		diskPath            string
 		CreateWorkPoolSize  int
 		DeleteWorkPoolSize  int
 		ReadWorkPoolSize    int
@@ -54,6 +57,7 @@ var _ = Describe("Depot", func() {
 		DeleteWorkPoolSize = 5
 		ReadWorkPoolSize = 5
 		MetricsWorkPoolSize = 5
+		diskPath = ""
 	})
 
 	JustBeforeEach(func() {
@@ -69,6 +73,7 @@ var _ = Describe("Depot", func() {
 		depotClient = depot.NewClient(
 			resources, containerStore, gardenClient, volmanClient, eventHub,
 			creationWorkPool, deletionWorkPool, readWorkPool, metricsWorkPool,
+			diskPath,
 		)
 	})
 
@@ -709,9 +714,34 @@ var _ = Describe("Depot", func() {
 	})
 
 	Describe("TotalResources", func() {
-		Context("when asked for total resources", func() {
-			It("should return the resources it was configured with", func() {
+		Context("when no disk path is configured", func() {
+			It("returns the frozen startup resources", func() {
 				Expect(depotClient.TotalResources(logger)).To(Equal(resources))
+			})
+		})
+
+		Context("when disk path is configured", func() {
+			var tmpDir string
+
+			BeforeEach(func() {
+				var err error
+				tmpDir, err = os.MkdirTemp("", "depot-disk-test")
+				Expect(err).NotTo(HaveOccurred())
+				diskPath = tmpDir
+				resources.DiskMB = math.MaxInt32
+			})
+
+			AfterEach(func() {
+				os.RemoveAll(tmpDir)
+			})
+
+			It("returns live disk capacity from syscall.Statfs instead of frozen startup value", func() {
+				result, err := depotClient.TotalResources(logger)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.MemoryMB).To(Equal(resources.MemoryMB))
+				Expect(result.Containers).To(Equal(resources.Containers))
+				Expect(result.DiskMB).NotTo(Equal(math.MaxInt32))
+				Expect(result.DiskMB).To(BeNumerically(">", 0))
 			})
 		})
 	})

--- a/initializer/initializer.go
+++ b/initializer/initializer.go
@@ -86,6 +86,7 @@ type ExecutorConfig struct {
 	InstanceIdentityPrivateKeyPath        string                `json:"instance_identity_private_key_path,omitempty"`
 	InstanceIdentityValidityPeriod        durationjson.Duration `json:"instance_identity_validity_period,omitempty"`
 	MaxCacheSizeInBytes                   uint64                `json:"max_cache_size_in_bytes,omitempty"`
+	MinCachePartitionFreeBytes            uint64                `json:"min_cache_partition_free_bytes,omitempty"`
 	MaxConcurrentDownloads                int                   `json:"max_concurrent_downloads,omitempty"`
 	MaxLogLinesPerSecond                  int                   `json:"max_log_lines_per_second"`
 	MemoryMB                              string                `json:"memory_mb,omitempty"`

--- a/initializer/initializer_garden.go
+++ b/initializer/initializer_garden.go
@@ -41,6 +41,7 @@ const (
 	maxConcurrentUploads           = 5
 	metricsReportInterval          = 1 * time.Minute
 	megabytesToBytes               = 1024 * 1024
+	defaultMinCachePartitionFreeBytes = 5 * 1024 * 1024 * 1024
 )
 
 type executorContainers struct {
@@ -131,7 +132,11 @@ func Initialize(
 	downloader := cacheddownloader.NewDownloader(10*time.Minute, math.MaxInt8, assetTLSConfig)
 	uploader := uploader.New(logger, 10*time.Minute, assetTLSConfig)
 
-	cache := cacheddownloader.NewCache(config.CachePath, int64(config.MaxCacheSizeInBytes))
+	minFree := int64(config.MinCachePartitionFreeBytes)
+	if minFree == 0 {
+		minFree = defaultMinCachePartitionFreeBytes
+	}
+	cache := cacheddownloader.NewCache(config.CachePath, int64(config.MaxCacheSizeInBytes), minFree)
 	cachedDownloader, err := cacheddownloader.New(
 		downloader,
 		cache,
@@ -265,6 +270,7 @@ func Initialize(
 		deletionWorkPool,
 		readWorkPool,
 		metricsWorkPool,
+		config.CachePath,
 	)
 
 	healthcheckSpec := garden.ProcessSpec{

--- a/initializer/initializer_test.go
+++ b/initializer/initializer_test.go
@@ -731,7 +731,7 @@ var _ = Describe("Initializer", func() {
 				Expect(tlsConfig).NotTo(BeNil())
 
 				newDownloader := cacheddownloader.NewDownloader(10*time.Minute, math.MaxInt8, tlsConfig)
-				newCache := cacheddownloader.NewCache(config.CachePath, int64(config.MaxCacheSizeInBytes))
+				newCache := cacheddownloader.NewCache(config.CachePath, int64(config.MaxCacheSizeInBytes), 0)
 
 				newCachedDownloader, err := cacheddownloader.New(
 					newDownloader,


### PR DESCRIPTION
ai-assisted=yes
TNZ-111552

- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
<!---
- Briefly explain why this PR is necessary
- Provide details of where this request is coming from including links, GitHub Issues, etc..
- Provide details of prior work (if applicable) including links to commits, github issues, etc...
--->


Backward Compatibility
---------------
Breaking Change? **Yes/No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
