### PR TITLE
fix: move live Statfs to RemainingResources; use *uint64 for min-free…

### DIFF
--- a/depot/depot.go
+++ b/depot/depot.go
@@ -220,7 +220,17 @@ func (c *client) DeleteContainer(logger lager.Logger, traceID string, guid strin
 
 func (c *client) RemainingResources(logger lager.Logger) (executor.ExecutorResources, error) {
 	logger = logger.Session("remaining-resources")
-	return c.containerStore.RemainingResources(logger), nil
+	remaining := c.containerStore.RemainingResources(logger)
+	if c.diskPath != "" {
+		var stat syscall.Statfs_t
+		if err := syscall.Statfs(c.diskPath, &stat); err == nil {
+			liveDiskMB := int(int64(stat.Bavail) * int64(stat.Bsize) / (1024 * 1024))
+			if liveDiskMB < remaining.DiskMB {
+				remaining.DiskMB = liveDiskMB
+			}
+		}
+	}
+	return remaining, nil
 }
 
 func (c *client) Ping(logger lager.Logger) error {
@@ -228,16 +238,9 @@ func (c *client) Ping(logger lager.Logger) error {
 }
 
 func (c *client) TotalResources(logger lager.Logger) (executor.ExecutorResources, error) {
-	diskMB := c.totalCapacity.DiskMB
-	if c.diskPath != "" {
-		var stat syscall.Statfs_t
-		if err := syscall.Statfs(c.diskPath, &stat); err == nil {
-			diskMB = int(int64(stat.Bavail) * int64(stat.Bsize) / (1024 * 1024))
-		}
-	}
 	return executor.ExecutorResources{
 		MemoryMB:   c.totalCapacity.MemoryMB,
-		DiskMB:     diskMB,
+		DiskMB:     c.totalCapacity.DiskMB,
 		Containers: c.totalCapacity.Containers,
 	}, nil
 }

--- a/depot/depot_test.go
+++ b/depot/depot_test.go
@@ -699,50 +699,46 @@ var _ = Describe("Depot", func() {
 	})
 
 	Describe("RemainingResources", func() {
-		var resources executor.ExecutorResources
+		var remainingResources executor.ExecutorResources
 
 		BeforeEach(func() {
-			resources = executor.NewExecutorResources(1024, 1024, 3)
-			containerStore.RemainingResourcesReturns(resources)
+			remainingResources = executor.NewExecutorResources(1024, 1024, 3)
+			containerStore.RemainingResourcesReturns(remainingResources)
 		})
 
 		It("should reduce resources used by allocated and running containers", func() {
 			actualResources, err := depotClient.RemainingResources(logger)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(actualResources).To(Equal(resources))
-		})
-	})
-
-	Describe("TotalResources", func() {
-		Context("when no disk path is configured", func() {
-			It("returns the frozen startup resources", func() {
-				Expect(depotClient.TotalResources(logger)).To(Equal(resources))
-			})
+			Expect(actualResources).To(Equal(remainingResources))
 		})
 
-		Context("when disk path is configured", func() {
+		Context("when disk path is configured and partition has less space than the store reports", func() {
 			var tmpDir string
 
 			BeforeEach(func() {
 				var err error
-				tmpDir, err = os.MkdirTemp("", "depot-disk-test")
+				tmpDir, err = os.MkdirTemp("", "depot-remaining-disk-test")
 				Expect(err).NotTo(HaveOccurred())
 				diskPath = tmpDir
-				resources.DiskMB = math.MaxInt32
+				containerStore.RemainingResourcesReturns(executor.NewExecutorResources(1024, math.MaxInt32, 3))
 			})
 
 			AfterEach(func() {
 				os.RemoveAll(tmpDir)
 			})
 
-			It("returns live disk capacity from syscall.Statfs instead of frozen startup value", func() {
-				result, err := depotClient.TotalResources(logger)
+			It("caps remaining disk at the live partition free space from syscall.Statfs", func() {
+				result, err := depotClient.RemainingResources(logger)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(result.MemoryMB).To(Equal(resources.MemoryMB))
-				Expect(result.Containers).To(Equal(resources.Containers))
 				Expect(result.DiskMB).NotTo(Equal(math.MaxInt32))
 				Expect(result.DiskMB).To(BeNumerically(">", 0))
 			})
+		})
+	})
+
+	Describe("TotalResources", func() {
+		It("returns the static startup resources", func() {
+			Expect(depotClient.TotalResources(logger)).To(Equal(resources))
 		})
 	})
 

--- a/initializer/initializer.go
+++ b/initializer/initializer.go
@@ -86,7 +86,7 @@ type ExecutorConfig struct {
 	InstanceIdentityPrivateKeyPath        string                `json:"instance_identity_private_key_path,omitempty"`
 	InstanceIdentityValidityPeriod        durationjson.Duration `json:"instance_identity_validity_period,omitempty"`
 	MaxCacheSizeInBytes                   uint64                `json:"max_cache_size_in_bytes,omitempty"`
-	MinCachePartitionFreeBytes            uint64                `json:"min_cache_partition_free_bytes,omitempty"`
+	MinCachePartitionFreeBytes            *uint64               `json:"min_cache_partition_free_bytes,omitempty"`
 	MaxConcurrentDownloads                int                   `json:"max_concurrent_downloads,omitempty"`
 	MaxLogLinesPerSecond                  int                   `json:"max_log_lines_per_second"`
 	MemoryMB                              string                `json:"memory_mb,omitempty"`

--- a/initializer/initializer_garden.go
+++ b/initializer/initializer_garden.go
@@ -132,9 +132,9 @@ func Initialize(
 	downloader := cacheddownloader.NewDownloader(10*time.Minute, math.MaxInt8, assetTLSConfig)
 	uploader := uploader.New(logger, 10*time.Minute, assetTLSConfig)
 
-	minFree := int64(config.MinCachePartitionFreeBytes)
-	if minFree == 0 {
-		minFree = defaultMinCachePartitionFreeBytes
+	minFree := int64(defaultMinCachePartitionFreeBytes)
+	if config.MinCachePartitionFreeBytes != nil {
+		minFree = int64(*config.MinCachePartitionFreeBytes)
 	}
 	cache := cacheddownloader.NewCache(config.CachePath, int64(config.MaxCacheSizeInBytes), minFree)
 	cachedDownloader, err := cacheddownloader.New(


### PR DESCRIPTION


- TotalResources reverts to static startup value to keep total-remaining arithmetic consistent for BBS metrics
- RemainingResources caps reported DiskMB at live partition free space (syscall.Statfs), so schedulers see reduced capacity when disk fills
- MinCachePartitionFreeBytes changed to *uint64: nil means use the 5 GB default, 0 explicitly disables the check (previously impossible)

ai-assisted=yes
TNZ-111552

- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
<!---
- Briefly explain why this PR is necessary
- Provide details of where this request is coming from including links, GitHub Issues, etc..
- Provide details of prior work (if applicable) including links to commits, github issues, etc...
--->


Backward Compatibility
---------------
Breaking Change? **Yes/No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
