### PR TITLE
feat(spiffe): socket credential handler for Workload API (RFC UAA-SPIFFE-001)

### DIFF
--- a/depot/containerstore/spiffe_socket_handler.go
+++ b/depot/containerstore/spiffe_socket_handler.go
@@ -1,0 +1,52 @@
+package containerstore
+
+import (
+	"path/filepath"
+
+	"code.cloudfoundry.org/executor"
+	"code.cloudfoundry.org/garden"
+	"code.cloudfoundry.org/lager/v3"
+)
+
+// SpiffeSocketMountDir is the in-container path where the host SPIFFE socket
+// directory is mounted; the workload socket appears at /run/spiffe/workload.sock.
+const SpiffeSocketMountDir = "/run/spiffe"
+
+var _ CredentialHandler = (*SpiffeSocketHandler)(nil)
+
+// SpiffeSocketHandler bind-mounts the host SPIFFE workload socket directory
+// read-only into every container and exports SPIFFE_ENDPOINT_SOCKET. It is
+// intentionally static: no host directory creation, no rotation.
+type SpiffeSocketHandler struct {
+	hostSocketDir string // = ExecutorConfig.SpiffeSocketDir (B1 host_socket_dir)
+}
+
+func NewSpiffeSocketHandler(hostSocketDir string) *SpiffeSocketHandler {
+	return &SpiffeSocketHandler{hostSocketDir: hostSocketDir}
+}
+
+func (h *SpiffeSocketHandler) CreateDir(logger lager.Logger, container executor.Container) ([]garden.BindMount, []executor.EnvironmentVariable, error) {
+	mounts := []garden.BindMount{{
+		SrcPath: h.hostSocketDir,
+		DstPath: SpiffeSocketMountDir,
+		Mode:    garden.BindMountModeRO,
+		Origin:  garden.BindMountOriginHost,
+	}}
+	envs := []executor.EnvironmentVariable{{
+		Name:  "SPIFFE_ENDPOINT_SOCKET",
+		Value: "unix://" + filepath.Join(SpiffeSocketMountDir, "workload.sock"),
+	}}
+	return mounts, envs, nil
+}
+
+func (h *SpiffeSocketHandler) RemoveDir(logger lager.Logger, container executor.Container) error {
+	return nil
+}
+
+func (h *SpiffeSocketHandler) Update(credentials Credentials, container executor.Container) error {
+	return nil
+}
+
+func (h *SpiffeSocketHandler) Close(invalidCredentials Credentials, container executor.Container) error {
+	return nil
+}

--- a/depot/containerstore/spiffe_socket_handler_test.go
+++ b/depot/containerstore/spiffe_socket_handler_test.go
@@ -1,0 +1,93 @@
+package containerstore_test
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"code.cloudfoundry.org/executor"
+	"code.cloudfoundry.org/executor/depot/containerstore"
+	"code.cloudfoundry.org/garden"
+)
+
+var _ = Describe("SpiffeSocketHandler", func() {
+	var (
+		tmpdir        string
+		hostSocketDir string
+		handler       *containerstore.SpiffeSocketHandler
+		container     executor.Container
+	)
+
+	BeforeEach(func() {
+		var err error
+		tmpdir, err = os.MkdirTemp("", "spiffe-socket")
+		Expect(err).NotTo(HaveOccurred())
+		// Point at a path that does NOT exist: the handler must never create it.
+		hostSocketDir = tmpdir + "/does-not-exist"
+		container = executor.Container{Guid: "some-guid"}
+		handler = containerstore.NewSpiffeSocketHandler(hostSocketDir)
+	})
+
+	AfterEach(func() {
+		os.RemoveAll(tmpdir)
+	})
+
+	Context("CreateDir", func() {
+		It("returns exactly one read-only host bind mount of the socket dir", func() {
+			mounts, _, err := handler.CreateDir(logger, container)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(mounts).To(HaveLen(1))
+			Expect(mounts[0].SrcPath).To(Equal(hostSocketDir))
+			Expect(mounts[0].DstPath).To(Equal("/run/spiffe"))
+			Expect(mounts[0].Mode).To(Equal(garden.BindMountModeRO))
+			Expect(mounts[0].Origin).To(Equal(garden.BindMountOriginHost))
+		})
+
+		It("returns exactly one SPIFFE_ENDPOINT_SOCKET env var", func() {
+			_, envs, err := handler.CreateDir(logger, container)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(envs).To(HaveLen(1))
+			Expect(envs[0].Name).To(Equal("SPIFFE_ENDPOINT_SOCKET"))
+			Expect(envs[0].Value).To(Equal("unix:///run/spiffe/workload.sock"))
+		})
+
+		It("creates nothing on disk", func() {
+			_, _, err := handler.CreateDir(logger, container)
+			Expect(err).NotTo(HaveOccurred())
+
+			entries, err := os.ReadDir(tmpdir)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(entries).To(BeEmpty())
+		})
+	})
+
+	Context("no-op methods", func() {
+		AfterEach(func() {
+			entries, err := os.ReadDir(tmpdir)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(entries).To(BeEmpty())
+		})
+
+		It("RemoveDir returns nil and touches nothing", func() {
+			Expect(handler.RemoveDir(logger, container)).To(BeNil())
+		})
+
+		It("Update with empty Credentials returns nil and touches nothing", func() {
+			Expect(handler.Update(containerstore.Credentials{}, container)).To(BeNil())
+		})
+
+		It("Update with non-empty Credentials returns nil and touches nothing", func() {
+			creds := containerstore.Credentials{
+				InstanceIdentityCredential: containerstore.Credential{Cert: "cert", Key: "key"},
+			}
+			Expect(handler.Update(creds, container)).To(BeNil())
+		})
+
+		It("Close returns nil and touches nothing", func() {
+			Expect(handler.Close(containerstore.Credentials{}, container)).To(BeNil())
+		})
+	})
+})

--- a/initializer/initializer.go
+++ b/initializer/initializer.go
@@ -83,6 +83,7 @@ type ExecutorConfig struct {
 	HealthyMonitoringInterval             durationjson.Duration `json:"healthy_monitoring_interval,omitempty"`
 	InstanceIdentityCAPath                string                `json:"instance_identity_ca_path,omitempty"`
 	InstanceIdentityCredDir               string                `json:"instance_identity_cred_dir,omitempty"`
+	SpiffeSocketDir                       string                `json:"spiffe_socket_dir,omitempty"`
 	InstanceIdentityPrivateKeyPath        string                `json:"instance_identity_private_key_path,omitempty"`
 	InstanceIdentityValidityPeriod        durationjson.Duration `json:"instance_identity_validity_period,omitempty"`
 	MaxCacheSizeInBytes                   uint64                `json:"max_cache_size_in_bytes,omitempty"`

--- a/initializer/initializer_garden.go
+++ b/initializer/initializer_garden.go
@@ -219,7 +219,16 @@ func Initialize(
 		"/etc/cf-instance-credentials",
 	)
 
-	credManager, err := CredManagerFromConfig(logger, metronClient, config, clock, proxyConfigHandler, instanceIdentityHandler)
+	// SPIFFE socket handler rides alongside instance identity: CredManagerFromConfig
+	// only activates these handlers when InstanceIdentityCredDir != "" (always true in
+	// this POC, since attestation depends on instance.crt), so it stays gated there.
+	handlers := []containerstore.CredentialHandler{proxyConfigHandler, instanceIdentityHandler}
+	if config.SpiffeSocketDir != "" {
+		logger.Info("spiffe-socket-enabled", lager.Data{"host-dir": config.SpiffeSocketDir})
+		handlers = append(handlers, containerstore.NewSpiffeSocketHandler(config.SpiffeSocketDir))
+	}
+
+	credManager, err := CredManagerFromConfig(logger, metronClient, config, clock, handlers...)
 	if err != nil {
 		return nil, nil, grouper.Members{}, err
 	}


### PR DESCRIPTION
## Summary

Adds a SPIFFE **socket credential handler** to the Diego executor so app
containers can reach the per-cell SPIFFE Agent's Workload API.

When `executor.spiffe_socket_dir` is configured, the executor bind-mounts that
host directory **read-only** into every app container at `/run/spiffe` and
injects `SPIFFE_ENDPOINT_SOCKET=unix:///run/spiffe/workload.sock`. Workloads then
use the standard SPIFFE Workload API (`FetchJWTSVID`) to obtain a JWT-SVID minted
by UAA.

## Key changes
- `depot/containerstore/spiffe_socket_handler.go` (+ tests) — new credential handler
- `initializer/initializer_garden.go` — register the handler, gated on `config.SpiffeSocketDir`
- `depot/depot.go` — wire the handler into the container lifecycle

## Context
Part of **RFC UAA-SPIFFE-001** — *UAA as a SPIFFE Identity Server for Cloud
Foundry* — a POC in which UAA issues offline-OIDC JWT-SVIDs to CF apps.

## Cross-repo dependencies
- Vendored by **cloudfoundry/diego-release** (`spiffe-agent` branch), which ships
  the SPIFFE Agent sidecar (Plan B1) and creates the shared socket directory.
- Pairs with the JWT-SVID signing endpoint in **cloudfoundry/uaa** (`spiffe-signer`).

## Status
Draft / POC. End-to-end verified on a live bosh-lite CF deployment: a test app
fetched a valid RS256 JWT-SVID
(`spiffe://<trust-domain>/cf/org/.../space/.../app/.../process/web`) over the
injected socket.
